### PR TITLE
Making search table a little more responsive

### DIFF
--- a/dashboard/sass/_pages.sass
+++ b/dashboard/sass/_pages.sass
@@ -3,10 +3,12 @@
 .search-form
   margin-top: 10px
 
+.search-result .created-at
+  white-space: nowrap
+
 
 .search-result h3
-  margin-bottom: 0
-  color: #1E0FBE
+  margin: 0 0 2px 0 
 
 
 .search-result .search-link
@@ -15,7 +17,7 @@
 
 .search-result p
   font-size: 12px
-  margin-top: 5px
+  margin-top: 3px
 
 
 /* CONTACTS */
@@ -1349,5 +1351,3 @@ table.shoping-cart-table
 
 body.body-small .vote-icon
   display: none
-
-

--- a/dashboard/src/css/style.css
+++ b/dashboard/src/css/style.css
@@ -2,118 +2,75 @@
 /* INSPINIA - Responsive Admin Theme version 2.7.1 */
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700");
 @import url("https://fonts.googleapis.com/css?family=Roboto:400,300,500,700");
-/* line 1, ../../sass/_typography.sass */
 h1, h2, h3, h4, h5, h6 {
-  font-weight: 100;
-}
+  font-weight: 100; }
 
-/* line 5, ../../sass/_typography.sass */
 h1 {
-  font-size: 30px;
-}
+  font-size: 30px; }
 
-/* line 9, ../../sass/_typography.sass */
 h2 {
-  font-size: 24px;
-}
+  font-size: 24px; }
 
-/* line 13, ../../sass/_typography.sass */
 h3 {
-  font-size: 16px;
-}
+  font-size: 16px; }
 
-/* line 17, ../../sass/_typography.sass */
 h4 {
-  font-size: 14px;
-}
+  font-size: 14px; }
 
-/* line 21, ../../sass/_typography.sass */
 h5 {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 25, ../../sass/_typography.sass */
 h6 {
-  font-size: 10px;
-}
+  font-size: 10px; }
 
-/* line 29, ../../sass/_typography.sass */
 h3, h4, h5 {
   margin-top: 5px;
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 1, ../../sass/_navigation.sass */
 .nav > li > a {
   color: #a7b1c2;
   font-weight: 600;
-  padding: 14px 20px 14px 25px;
-}
+  padding: 14px 20px 14px 25px; }
 
-/* line 7, ../../sass/_navigation.sass */
 .nav.navbar-right > li > a {
-  color: #999c9e;
-}
+  color: #999c9e; }
 
-/* line 11, ../../sass/_navigation.sass */
 .nav > li.active > a {
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 15, ../../sass/_navigation.sass */
 .navbar-default .nav > li > a:hover, .navbar-default .nav > li > a:focus {
   background-color: #293846;
-  color: white;
-}
+  color: white; }
 
-/* line 20, ../../sass/_navigation.sass */
 .nav .open > a, .nav .open > a:hover, .nav .open > a:focus {
-  background: #fff;
-}
+  background: #fff; }
 
-/* line 24, ../../sass/_navigation.sass */
 .nav.navbar-top-links > li > a:hover, .nav.navbar-top-links > li > a:focus {
-  background-color: transparent;
-}
+  background-color: transparent; }
 
-/* line 28, ../../sass/_navigation.sass */
 .nav > li > a i {
-  margin-right: 6px;
-}
+  margin-right: 6px; }
 
-/* line 32, ../../sass/_navigation.sass */
 .navbar {
-  border: 0;
-}
+  border: 0; }
 
-/* line 36, ../../sass/_navigation.sass */
 .navbar-default {
   background-color: transparent;
-  border-color: #2F4050;
-}
+  border-color: #2F4050; }
 
-/* line 41, ../../sass/_navigation.sass */
 .navbar-top-links li {
-  display: inline-block;
-}
+  display: inline-block; }
 
-/* line 45, ../../sass/_navigation.sass */
 .navbar-top-links li:last-child {
-  margin-right: 40px;
-}
+  margin-right: 40px; }
 
-/* line 49, ../../sass/_navigation.sass */
 .body-small .navbar-top-links li:last-child {
-  margin-right: 0;
-}
+  margin-right: 0; }
 
-/* line 53, ../../sass/_navigation.sass */
 .navbar-top-links li a {
   padding: 20px 10px;
-  min-height: 50px;
-}
+  min-height: 50px; }
 
-/* line 58, ../../sass/_navigation.sass */
 .dropdown-menu {
   border: medium none;
   border-radius: 3px;
@@ -127,343 +84,233 @@ h3, h4, h5 {
   position: absolute;
   text-shadow: none;
   top: 100%;
-  z-index: 1000;
-}
+  z-index: 1000; }
 
-/* line 74, ../../sass/_navigation.sass */
 .dropdown-menu > li > a {
   border-radius: 3px;
   color: inherit;
   line-height: 25px;
   margin: 4px;
   text-align: left;
-  font-weight: normal;
-}
+  font-weight: normal; }
 
-/* line 82, ../../sass/_navigation.sass */
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:focus,
 .dropdown-menu > .active > a:hover {
   color: #fff;
   text-decoration: none;
   background-color: #1ab394;
-  outline: 0;
-}
+  outline: 0; }
 
-/* line 91, ../../sass/_navigation.sass */
 .dropdown-menu > li > a.font-bold {
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 95, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-menu li {
-  display: block;
-}
+  display: block; }
 
-/* line 99, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-menu li:last-child {
-  margin-right: 0;
-}
+  margin-right: 0; }
 
-/* line 103, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-menu li a {
   padding: 3px 20px;
-  min-height: 0;
-}
+  min-height: 0; }
 
-/* line 108, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-menu li a div {
-  white-space: normal;
-}
+  white-space: normal; }
 
-/* line 112, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-messages,
 .navbar-top-links .dropdown-tasks,
 .navbar-top-links .dropdown-alerts {
   width: 310px;
-  min-width: 0;
-}
+  min-width: 0; }
 
-/* line 119, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-messages {
-  margin-left: 5px;
-}
+  margin-left: 5px; }
 
-/* line 123, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-tasks {
-  margin-left: -59px;
-}
+  margin-left: -59px; }
 
-/* line 127, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-alerts {
-  margin-left: -123px;
-}
+  margin-left: -123px; }
 
-/* line 131, ../../sass/_navigation.sass */
 .navbar-top-links .dropdown-user {
   right: 0;
-  left: auto;
-}
+  left: auto; }
 
-/* line 136, ../../sass/_navigation.sass */
 .dropdown-messages, .dropdown-alerts {
-  padding: 10px 10px 10px 10px;
-}
+  padding: 10px 10px 10px 10px; }
 
-/* line 140, ../../sass/_navigation.sass */
 .dropdown-messages li a, .dropdown-alerts li a {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 144, ../../sass/_navigation.sass */
 .dropdown-messages li em, .dropdown-alerts li em {
-  font-size: 10px;
-}
+  font-size: 10px; }
 
-/* line 148, ../../sass/_navigation.sass */
 .nav.navbar-top-links .dropdown-alerts a {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 152, ../../sass/_navigation.sass */
 .nav-header {
   padding: 33px 25px;
   background-color: #2F4050;
-  background-image: url("patterns/header-profile.png");
-}
+  background-image: url("patterns/header-profile.png"); }
 
-/* line 159, ../../sass/_navigation.sass */
 .pace-done .nav-header {
-  transition: all 0.4s;
-}
+  transition: all 0.4s; }
 
-/* line 163, ../../sass/_navigation.sass */
 .nav > li.active {
   border-left: 4px solid #19aa8d;
-  background: #293846;
-}
+  background: #293846; }
 
-/* line 168, ../../sass/_navigation.sass */
 .nav.nav-second-level > li.active {
-  border: none;
-}
+  border: none; }
 
-/* line 172, ../../sass/_navigation.sass */
 .nav.nav-second-level.collapse[style] {
-  height: auto !important;
-}
+  height: auto !important; }
 
-/* line 176, ../../sass/_navigation.sass */
 .nav-header a {
-  color: #DFE4ED;
-}
+  color: #DFE4ED; }
 
-/* line 180, ../../sass/_navigation.sass */
 .nav-header .text-muted {
-  color: #8095a8;
-}
+  color: #8095a8; }
 
-/* line 184, ../../sass/_navigation.sass */
 .minimalize-styl-2 {
   padding: 4px 12px;
   margin: 14px 5px 5px 20px;
   font-size: 14px;
-  float: left;
-}
+  float: left; }
 
-/* line 191, ../../sass/_navigation.sass */
 .navbar-form-custom {
   float: left;
   height: 50px;
   padding: 0;
   width: 200px;
-  display: block;
-}
+  display: block; }
 
-/* line 199, ../../sass/_navigation.sass */
 .navbar-form-custom .form-group {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 203, ../../sass/_navigation.sass */
 .nav.navbar-top-links a {
-  font-size: 14px;
-}
+  font-size: 14px; }
 
-/* line 207, ../../sass/_navigation.sass */
 .navbar-form-custom .form-control {
   background: none repeat scroll 0 0 transparent;
   border: medium none;
   font-size: 14px;
   height: 60px;
   margin: 0;
-  z-index: 2000;
-}
+  z-index: 2000; }
 
-/* line 216, ../../sass/_navigation.sass */
 .count-info .label {
   line-height: 12px;
   padding: 2px 5px;
   position: absolute;
   right: 6px;
-  top: 12px;
-}
+  top: 12px; }
 
-/* line 224, ../../sass/_navigation.sass */
 .arrow {
-  float: right;
-}
+  float: right; }
 
-/* line 228, ../../sass/_navigation.sass */
 .fa.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 232, ../../sass/_navigation.sass */
 .active > a > .fa.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 236, ../../sass/_navigation.sass */
 .nav-second-level li,
 .nav-third-level li {
-  border-bottom: none !important;
-}
+  border-bottom: none !important; }
 
-/* line 241, ../../sass/_navigation.sass */
 .nav-second-level li a {
   padding: 7px 10px 7px 10px;
-  padding-left: 52px;
-}
+  padding-left: 52px; }
 
-/* line 246, ../../sass/_navigation.sass */
 .nav-third-level li a {
-  padding-left: 62px;
-}
+  padding-left: 62px; }
 
-/* line 250, ../../sass/_navigation.sass */
 .nav-second-level li:last-child {
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 254, ../../sass/_navigation.sass */
 body:not(.fixed-sidebar):not(.canvas-menu).mini-navbar .nav li:hover > .nav-second-level,
 .mini-navbar .nav li:focus > .nav-second-level {
   display: block;
   border-radius: 0 2px 2px 0;
   min-width: 140px;
-  height: auto;
-}
+  height: auto; }
 
-/* line 262, ../../sass/_navigation.sass */
 body.mini-navbar .navbar-default .nav > li > .nav-second-level li a {
   font-size: 12px;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 267, ../../sass/_navigation.sass */
 .fixed-nav .slimScrollDiv #side-menu {
-  padding-bottom: 60px;
-}
+  padding-bottom: 60px; }
 
-/* line 271, ../../sass/_navigation.sass */
 .mini-navbar .nav-second-level li a {
-  padding: 10px 10px 10px 15px;
-}
+  padding: 10px 10px 10px 15px; }
 
-/* line 275, ../../sass/_navigation.sass */
 .mini-navbar .nav .nav-second-level {
   position: absolute;
   left: 70px;
   top: 0;
   background-color: #2F4050;
   padding: 10px 10px 10px 10px;
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 284, ../../sass/_navigation.sass */
 .canvas-menu.mini-navbar .nav-second-level {
-  background: #293846;
-}
+  background: #293846; }
 
-/* line 288, ../../sass/_navigation.sass */
 .mini-navbar li.active .nav-second-level {
-  left: 65px;
-}
+  left: 65px; }
 
-/* line 292, ../../sass/_navigation.sass */
 .navbar-default .special_link a {
   background: #1ab394;
-  color: white;
-}
+  color: white; }
 
-/* line 297, ../../sass/_navigation.sass */
 .navbar-default .special_link a:hover {
   background: #17987e !important;
-  color: white;
-}
+  color: white; }
 
-/* line 302, ../../sass/_navigation.sass */
 .navbar-default .special_link a span.label {
   background: #fff;
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 307, ../../sass/_navigation.sass */
 .navbar-default .landing_link a {
   background: #1cc09f;
-  color: white;
-}
+  color: white; }
 
-/* line 312, ../../sass/_navigation.sass */
 .navbar-default .landing_link a:hover {
   background: #1ab394 !important;
-  color: white;
-}
+  color: white; }
 
-/* line 317, ../../sass/_navigation.sass */
 .navbar-default .landing_link a span.label {
   background: #fff;
-  color: #1cc09f;
-}
+  color: #1cc09f; }
 
-/* line 322, ../../sass/_navigation.sass */
 .logo-element {
   text-align: center;
   font-size: 18px;
   font-weight: 600;
   color: white;
   display: none;
-  padding: 18px 0;
-}
+  padding: 18px 0; }
 
-/* line 331, ../../sass/_navigation.sass */
 .pace-done .navbar-static-side, .pace-done .nav-header, .pace-done li.active, .pace-done #page-wrapper, .pace-done .footer {
   -webkit-transition: all 0.4s;
   -moz-transition: all 0.4s;
   -o-transition: all 0.4s;
-  transition: all 0.4s;
-}
+  transition: all 0.4s; }
 
-/* line 338, ../../sass/_navigation.sass */
 .navbar-fixed-top {
   background: #fff;
   transition-duration: 0.4s;
   border-bottom: 1px solid #e7eaec !important;
-  z-index: 2030;
-}
+  z-index: 2030; }
 
-/* line 345, ../../sass/_navigation.sass */
 .navbar-fixed-top, .navbar-static-top {
-  background: #f3f3f4;
-}
+  background: #f3f3f4; }
 
-/* line 349, ../../sass/_navigation.sass */
 .fixed-nav #wrapper {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 352, ../../sass/_navigation.sass */
 .nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
   -moz-border-bottom-colors: none;
   -moz-border-left-colors: none;
@@ -476,670 +323,436 @@ body.mini-navbar .navbar-default .nav > li > .nav-second-level li a {
   border-style: solid;
   border-width: 1px;
   color: #555555;
-  cursor: default;
-}
+  cursor: default; }
 
-/* line 367, ../../sass/_navigation.sass */
 .nav.nav-tabs li {
   background: none;
-  border: none;
-}
+  border: none; }
 
-/* line 371, ../../sass/_navigation.sass */
 body.fixed-nav #wrapper .navbar-static-side,
 body.fixed-nav #wrapper #page-wrapper {
-  margin-top: 60px;
-}
+  margin-top: 60px; }
 
-/* line 376, ../../sass/_navigation.sass */
 body.top-navigation.fixed-nav #wrapper #page-wrapper {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 380, ../../sass/_navigation.sass */
 body.fixed-nav.fixed-nav-basic .navbar-fixed-top {
-  left: 220px;
-}
+  left: 220px; }
 
-/* line 384, ../../sass/_navigation.sass */
 body.fixed-nav.fixed-nav-basic.mini-navbar .navbar-fixed-top {
-  left: 70px;
-}
+  left: 70px; }
 
-/* line 388, ../../sass/_navigation.sass */
 body.fixed-nav.fixed-nav-basic.fixed-sidebar.mini-navbar .navbar-fixed-top {
-  left: 0;
-}
+  left: 0; }
 
-/* line 392, ../../sass/_navigation.sass */
 body.fixed-nav.fixed-nav-basic #wrapper .navbar-static-side {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 396, ../../sass/_navigation.sass */
 body.fixed-nav.fixed-nav-basic.body-small .navbar-fixed-top {
-  left: 0;
-}
+  left: 0; }
 
-/* line 400, ../../sass/_navigation.sass */
 body.fixed-nav.fixed-nav-basic.fixed-sidebar.mini-navbar.body-small .navbar-fixed-top {
-  left: 220px;
-}
+  left: 220px; }
 
-/* line 404, ../../sass/_navigation.sass */
 .fixed-nav .minimalize-styl-2 {
-  margin: 14px 5px 5px 15px;
-}
+  margin: 14px 5px 5px 15px; }
 
-/* line 408, ../../sass/_navigation.sass */
 .body-small .navbar-fixed-top {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
-/* line 412, ../../sass/_navigation.sass */
 body.mini-navbar .navbar-static-side {
-  width: 70px;
-}
+  width: 70px; }
 
-/* line 416, ../../sass/_navigation.sass */
 body.mini-navbar .profile-element, body.mini-navbar .nav-label, body.mini-navbar .navbar-default .nav li a span {
-  display: none;
-}
+  display: none; }
 
-/* line 420, ../../sass/_navigation.sass */
 body.canvas-menu .profile-element {
-  display: block;
-}
+  display: block; }
 
-/* line 424, ../../sass/_navigation.sass */
 body:not(.fixed-sidebar):not(.canvas-menu).mini-navbar .nav-second-level {
-  display: none;
-}
+  display: none; }
 
-/* line 428, ../../sass/_navigation.sass */
 body.mini-navbar .navbar-default .nav > li > a {
-  font-size: 16px;
-}
+  font-size: 16px; }
 
-/* line 432, ../../sass/_navigation.sass */
 body.mini-navbar .logo-element {
-  display: block;
-}
+  display: block; }
 
-/* line 436, ../../sass/_navigation.sass */
 body.canvas-menu .logo-element {
-  display: none;
-}
+  display: none; }
 
-/* line 440, ../../sass/_navigation.sass */
 body.mini-navbar .nav-header {
   padding: 0;
-  background-color: #1ab394;
-}
+  background-color: #1ab394; }
 
-/* line 445, ../../sass/_navigation.sass */
 body.canvas-menu .nav-header {
-  padding: 33px 25px;
-}
+  padding: 33px 25px; }
 
-/* line 449, ../../sass/_navigation.sass */
 body.mini-navbar #page-wrapper {
-  margin: 0 0 0 70px;
-}
+  margin: 0 0 0 70px; }
 
-/* line 453, ../../sass/_navigation.sass */
 body.fixed-sidebar.mini-navbar .footer,
 body.canvas-menu.mini-navbar .footer {
-  margin: 0 0 0 0 !important;
-}
+  margin: 0 0 0 0 !important; }
 
-/* line 458, ../../sass/_navigation.sass */
 body.canvas-menu.mini-navbar #page-wrapper,
 body.canvas-menu.mini-navbar .footer {
-  margin: 0 0 0 0;
-}
+  margin: 0 0 0 0; }
 
-/* line 463, ../../sass/_navigation.sass */
 body.fixed-sidebar .navbar-static-side,
 body.canvas-menu .navbar-static-side {
   position: fixed;
   width: 220px;
   z-index: 2001;
-  height: 100%;
-}
+  height: 100%; }
 
-/* line 471, ../../sass/_navigation.sass */
 body.fixed-sidebar.mini-navbar .navbar-static-side {
-  width: 0;
-}
+  width: 0; }
 
-/* line 475, ../../sass/_navigation.sass */
 body.fixed-sidebar.mini-navbar #page-wrapper {
-  margin: 0 0 0 0;
-}
+  margin: 0 0 0 0; }
 
-/* line 479, ../../sass/_navigation.sass */
 body.body-small.fixed-sidebar.mini-navbar #page-wrapper {
-  margin: 0 0 0 220px;
-}
+  margin: 0 0 0 220px; }
 
-/* line 483, ../../sass/_navigation.sass */
 body.body-small.fixed-sidebar.mini-navbar .navbar-static-side {
-  width: 220px;
-}
+  width: 220px; }
 
-/* line 487, ../../sass/_navigation.sass */
 .fixed-sidebar.mini-navbar .nav li:focus > .nav-second-level,
 .canvas-menu.mini-navbar .nav li:focus > .nav-second-level {
   display: block;
-  height: auto;
-}
+  height: auto; }
 
-/* line 493, ../../sass/_navigation.sass */
 body.fixed-sidebar.mini-navbar .navbar-default .nav > li > .nav-second-level li a {
   font-size: 12px;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 498, ../../sass/_navigation.sass */
 body.canvas-menu.mini-navbar .navbar-default .nav > li > .nav-second-level li a {
   font-size: 13px;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 503, ../../sass/_navigation.sass */
 .fixed-sidebar.mini-navbar .nav-second-level li a,
 .canvas-menu.mini-navbar .nav-second-level li a {
-  padding: 10px 10px 10px 15px;
-}
+  padding: 10px 10px 10px 15px; }
 
-/* line 508, ../../sass/_navigation.sass */
 .fixed-sidebar.mini-navbar .nav-second-level,
 .canvas-menu.mini-navbar .nav-second-level {
   position: relative;
   padding: 0;
-  font-size: 13px;
-}
+  font-size: 13px; }
 
-/* line 515, ../../sass/_navigation.sass */
 .fixed-sidebar.mini-navbar li.active .nav-second-level,
 .canvas-menu.mini-navbar li.active .nav-second-level {
-  left: 0;
-}
+  left: 0; }
 
-/* line 520, ../../sass/_navigation.sass */
 body.fixed-sidebar.mini-navbar .navbar-default .nav > li > a,
 body.canvas-menu.mini-navbar .navbar-default .nav > li > a {
-  font-size: 13px;
-}
+  font-size: 13px; }
 
-/* line 525, ../../sass/_navigation.sass */
 body.fixed-sidebar.mini-navbar .nav-label,
 body.fixed-sidebar.mini-navbar .navbar-default .nav li a span,
 body.canvas-menu.mini-navbar .nav-label,
 body.canvas-menu.mini-navbar .navbar-default .nav li a span {
-  display: inline;
-}
+  display: inline; }
 
-/* line 532, ../../sass/_navigation.sass */
 body.canvas-menu.mini-navbar .navbar-default .nav li .profile-element a span {
-  display: block;
-}
+  display: block; }
 
-/* line 536, ../../sass/_navigation.sass */
 .canvas-menu.mini-navbar .nav-second-level li a,
 .fixed-sidebar.mini-navbar .nav-second-level li a {
-  padding: 7px 10px 7px 52px;
-}
+  padding: 7px 10px 7px 52px; }
 
-/* line 541, ../../sass/_navigation.sass */
 .fixed-sidebar.mini-navbar .nav-second-level,
 .canvas-menu.mini-navbar .nav-second-level {
-  left: 0;
-}
+  left: 0; }
 
-/* line 546, ../../sass/_navigation.sass */
 body.canvas-menu nav.navbar-static-side {
   z-index: 2001;
   background: #2f4050;
   height: 100%;
   position: fixed;
-  display: none;
-}
+  display: none; }
 
-/* line 554, ../../sass/_navigation.sass */
 body.canvas-menu.mini-navbar nav.navbar-static-side {
   display: block;
-  width: 220px;
-}
+  width: 220px; }
 
-/* line 1, ../../sass/_top_navigation.sass */
 .top-navigation #page-wrapper {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
-/* line 5, ../../sass/_top_navigation.sass */
 .top-navigation .navbar-nav .dropdown-menu > .active > a {
   background: white;
   color: #1ab394;
-  font-weight: bold;
-}
+  font-weight: bold; }
 
-/* line 11, ../../sass/_top_navigation.sass */
 .white-bg .navbar-fixed-top, .white-bg .navbar-static-top {
-  background: #fff;
-}
+  background: #fff; }
 
-/* line 15, ../../sass/_top_navigation.sass */
 .top-navigation .navbar {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 19, ../../sass/_top_navigation.sass */
 .top-navigation .nav > li > a {
   padding: 15px 20px;
-  color: #676a6c;
-}
+  color: #676a6c; }
 
-/* line 24, ../../sass/_top_navigation.sass */
 .top-navigation .nav > li a:hover, .top-navigation .nav > li a:focus {
   background: #fff;
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 29, ../../sass/_top_navigation.sass */
 .top-navigation .navbar .nav > li.active {
   background: #fff;
-  border: none;
-}
+  border: none; }
 
-/* line 34, ../../sass/_top_navigation.sass */
 .top-navigation .nav > li.active > a {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 38, ../../sass/_top_navigation.sass */
 .top-navigation .navbar-right {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 42, ../../sass/_top_navigation.sass */
 .top-navigation .navbar-nav .dropdown-menu {
   box-shadow: none;
-  border: 1px solid #e7eaec;
-}
+  border: 1px solid #e7eaec; }
 
-/* line 47, ../../sass/_top_navigation.sass */
 .top-navigation .dropdown-menu > li > a {
   margin: 0;
-  padding: 7px 20px;
-}
+  padding: 7px 20px; }
 
-/* line 52, ../../sass/_top_navigation.sass */
 .navbar .dropdown-menu {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 56, ../../sass/_top_navigation.sass */
 .top-navigation .navbar-brand {
   background: #1ab394;
   color: #fff;
-  padding: 15px 25px;
-}
+  padding: 15px 25px; }
 
-/* line 62, ../../sass/_top_navigation.sass */
 .top-navigation .navbar-top-links li:last-child {
-  margin-right: 0;
-}
+  margin-right: 0; }
 
-/* line 66, ../../sass/_top_navigation.sass */
 .top-navigation.mini-navbar #page-wrapper,
 .top-navigation.body-small.fixed-sidebar.mini-navbar #page-wrapper,
 .mini-navbar .top-navigation #page-wrapper,
 .body-small.fixed-sidebar.mini-navbar .top-navigation #page-wrapper,
 .canvas-menu #page-wrapper {
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 74, ../../sass/_top_navigation.sass */
 .top-navigation.fixed-nav #wrapper, .fixed-nav #wrapper.top-navigation {
-  margin-top: 50px;
-}
+  margin-top: 50px; }
 
-/* line 78, ../../sass/_top_navigation.sass */
 .top-navigation .footer.fixed {
-  margin-left: 0 !important;
-}
+  margin-left: 0 !important; }
 
-/* line 82, ../../sass/_top_navigation.sass */
 .top-navigation .wrapper.wrapper-content {
-  padding: 40px;
-}
+  padding: 40px; }
 
-/* line 86, ../../sass/_top_navigation.sass */
 .top-navigation.body-small .wrapper.wrapper-content, .body-small .top-navigation .wrapper.wrapper-content {
-  padding: 40px 0 40px 0;
-}
+  padding: 40px 0 40px 0; }
 
-/* line 90, ../../sass/_top_navigation.sass */
 .navbar-toggle {
   background-color: #1ab394;
   color: #fff;
   padding: 6px 12px;
-  font-size: 14px;
-}
+  font-size: 14px; }
 
-/* line 97, ../../sass/_top_navigation.sass */
 .top-navigation .navbar-nav .open .dropdown-menu > li > a, .top-navigation .navbar-nav .open .dropdown-menu .dropdown-header {
-  padding: 10px 15px 10px 20px;
-}
+  padding: 10px 15px 10px 20px; }
 
 @media (max-width: 768px) {
-  /* line 102, ../../sass/_top_navigation.sass */
   .top-navigation .navbar-header {
     display: block;
-    float: none;
-  }
-}
-/* line 108, ../../sass/_top_navigation.sass */
+    float: none; } }
 .menu-visible-lg, .menu-visible-md {
-  display: none !important;
-}
+  display: none !important; }
 
 @media (min-width: 1200px) {
-  /* line 113, ../../sass/_top_navigation.sass */
   .menu-visible-lg {
-    display: block !important;
-  }
-}
+    display: block !important; } }
 @media (min-width: 992px) {
-  /* line 119, ../../sass/_top_navigation.sass */
   .menu-visible-md {
-    display: block !important;
-  }
-}
+    display: block !important; } }
 @media (max-width: 767px) {
-  /* line 125, ../../sass/_top_navigation.sass */
   .menu-visible-md {
-    display: block !important;
-  }
+    display: block !important; }
 
-  /* line 129, ../../sass/_top_navigation.sass */
   .menu-visible-lg {
-    display: block !important;
-  }
-}
-/* line 2, ../../sass/_buttons.sass */
+    display: block !important; } }
 .btn {
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 6, ../../sass/_buttons.sass */
 .float-e-margins .btn {
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
-/* line 10, ../../sass/_buttons.sass */
 .btn-w-m {
-  min-width: 120px;
-}
+  min-width: 120px; }
 
-/* line 14, ../../sass/_buttons.sass */
 .btn-primary.btn-outline {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 18, ../../sass/_buttons.sass */
 .btn-success.btn-outline {
-  color: #1c84c6;
-}
+  color: #1c84c6; }
 
-/* line 22, ../../sass/_buttons.sass */
 .btn-info.btn-outline {
-  color: #23c6c8;
-}
+  color: #23c6c8; }
 
-/* line 26, ../../sass/_buttons.sass */
 .btn-warning.btn-outline {
-  color: #f8ac59;
-}
+  color: #f8ac59; }
 
-/* line 30, ../../sass/_buttons.sass */
 .btn-danger.btn-outline {
-  color: #ED5565;
-}
+  color: #ED5565; }
 
-/* line 34, ../../sass/_buttons.sass */
 .btn-primary.btn-outline:hover,
 .btn-success.btn-outline:hover,
 .btn-info.btn-outline:hover,
 .btn-warning.btn-outline:hover,
 .btn-danger.btn-outline:hover {
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 42, ../../sass/_buttons.sass */
 .btn-primary {
   background-color: #1ab394;
   border-color: #1ab394;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 48, ../../sass/_buttons.sass */
 .btn-primary:hover, .btn-primary:focus, .btn-primary:active, .btn-primary.active, .open .dropdown-toggle.btn-primary, .btn-primary:active:focus, .btn-primary:active:hover, .btn-primary.active:hover, .btn-primary.active:focus {
   background-color: #18a689;
   border-color: #18a689;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 54, ../../sass/_buttons.sass */
 .btn-primary:active, .btn-primary.active, .open .dropdown-toggle.btn-primary {
-  background-image: none;
-}
+  background-image: none; }
 
-/* line 58, ../../sass/_buttons.sass */
 .btn-primary.disabled, .btn-primary.disabled:hover, .btn-primary.disabled:focus, .btn-primary.disabled:active, .btn-primary.disabled.active, .btn-primary[disabled], .btn-primary[disabled]:hover, .btn-primary[disabled]:focus, .btn-primary[disabled]:active, .btn-primary.active[disabled], fieldset[disabled] .btn-primary, fieldset[disabled] .btn-primary:hover, fieldset[disabled] .btn-primary:focus, fieldset[disabled] .btn-primary:active, fieldset[disabled] .btn-primary.active {
   background-color: #1dc5a3;
-  border-color: #1dc5a3;
-}
+  border-color: #1dc5a3; }
 
-/* line 63, ../../sass/_buttons.sass */
 .btn-success {
   background-color: #1c84c6;
   border-color: #1c84c6;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 69, ../../sass/_buttons.sass */
 .btn-success:hover, .btn-success:focus, .btn-success:active, .btn-success.active, .open .dropdown-toggle.btn-success, .btn-success:active:focus, .btn-success:active:hover, .btn-success.active:hover, .btn-success.active:focus {
   background-color: #1a7bb9;
   border-color: #1a7bb9;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 75, ../../sass/_buttons.sass */
 .btn-success:active, .btn-success.active, .open .dropdown-toggle.btn-success {
-  background-image: none;
-}
+  background-image: none; }
 
-/* line 79, ../../sass/_buttons.sass */
 .btn-success.disabled, .btn-success.disabled:hover, .btn-success.disabled:focus, .btn-success.disabled:active, .btn-success.disabled.active, .btn-success[disabled], .btn-success[disabled]:hover, .btn-success[disabled]:focus, .btn-success[disabled]:active, .btn-success.active[disabled], fieldset[disabled] .btn-success, fieldset[disabled] .btn-success:hover, fieldset[disabled] .btn-success:focus, fieldset[disabled] .btn-success:active, fieldset[disabled] .btn-success.active {
   background-color: #1f90d8;
-  border-color: #1f90d8;
-}
+  border-color: #1f90d8; }
 
-/* line 84, ../../sass/_buttons.sass */
 .btn-info {
   background-color: #23c6c8;
   border-color: #23c6c8;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 90, ../../sass/_buttons.sass */
 .btn-info:hover, .btn-info:focus, .btn-info:active, .btn-info.active, .open .dropdown-toggle.btn-info, .btn-info:active:focus, .btn-info:active:hover, .btn-info.active:hover, .btn-info.active:focus {
   background-color: #21b9bb;
   border-color: #21b9bb;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 96, ../../sass/_buttons.sass */
 .btn-info:active, .btn-info.active, .open .dropdown-toggle.btn-info {
-  background-image: none;
-}
+  background-image: none; }
 
-/* line 100, ../../sass/_buttons.sass */
 .btn-info.disabled, .btn-info.disabled:hover, .btn-info.disabled:focus, .btn-info.disabled:active, .btn-info.disabled.active, .btn-info[disabled], .btn-info[disabled]:hover, .btn-info[disabled]:focus, .btn-info[disabled]:active, .btn-info.active[disabled], fieldset[disabled] .btn-info, fieldset[disabled] .btn-info:hover, fieldset[disabled] .btn-info:focus, fieldset[disabled] .btn-info:active, fieldset[disabled] .btn-info.active {
   background-color: #26d7d9;
-  border-color: #26d7d9;
-}
+  border-color: #26d7d9; }
 
-/* line 105, ../../sass/_buttons.sass */
 .btn-default {
   color: inherit;
   background: white;
-  border: 1px solid #e7eaec;
-}
+  border: 1px solid #e7eaec; }
 
-/* line 111, ../../sass/_buttons.sass */
 .btn-default:hover, .btn-default:focus, .btn-default:active, .btn-default.active, .open .dropdown-toggle.btn-default, .btn-default:active:focus, .btn-default:active:hover, .btn-default.active:hover, .btn-default.active:focus {
   color: inherit;
-  border: 1px solid #d2d2d2;
-}
+  border: 1px solid #d2d2d2; }
 
-/* line 116, ../../sass/_buttons.sass */
 .btn-default:active, .btn-default.active, .open .dropdown-toggle.btn-default {
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15) inset;
-}
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15) inset; }
 
-/* line 120, ../../sass/_buttons.sass */
 .btn-default.disabled, .btn-default.disabled:hover, .btn-default.disabled:focus, .btn-default.disabled:active, .btn-default.disabled.active, .btn-default[disabled], .btn-default[disabled]:hover, .btn-default[disabled]:focus, .btn-default[disabled]:active, .btn-default.active[disabled], fieldset[disabled] .btn-default, fieldset[disabled] .btn-default:hover, fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default:active, fieldset[disabled] .btn-default.active {
-  color: #cacaca;
-}
+  color: #cacaca; }
 
-/* line 124, ../../sass/_buttons.sass */
 .btn-warning {
   background-color: #f8ac59;
   border-color: #f8ac59;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 130, ../../sass/_buttons.sass */
 .btn-warning:hover, .btn-warning:focus, .btn-warning:active, .btn-warning.active, .open .dropdown-toggle.btn-warning, .btn-warning:active:focus, .btn-warning:active:hover, .btn-warning.active:hover, .btn-warning.active:focus {
   background-color: #f7a54a;
   border-color: #f7a54a;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 136, ../../sass/_buttons.sass */
 .btn-warning:active, .btn-warning.active, .open .dropdown-toggle.btn-warning {
-  background-image: none;
-}
+  background-image: none; }
 
-/* line 140, ../../sass/_buttons.sass */
 .btn-warning.disabled, .btn-warning.disabled:hover, .btn-warning.disabled:focus, .btn-warning.disabled:active, .btn-warning.disabled.active, .btn-warning[disabled], .btn-warning[disabled]:hover, .btn-warning[disabled]:focus, .btn-warning[disabled]:active, .btn-warning.active[disabled], fieldset[disabled] .btn-warning, fieldset[disabled] .btn-warning:hover, fieldset[disabled] .btn-warning:focus, fieldset[disabled] .btn-warning:active, fieldset[disabled] .btn-warning.active {
   background-color: #f9b66d;
-  border-color: #f9b66d;
-}
+  border-color: #f9b66d; }
 
-/* line 145, ../../sass/_buttons.sass */
 .btn-danger {
   background-color: #ED5565;
   border-color: #ED5565;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 151, ../../sass/_buttons.sass */
 .btn-danger:hover, .btn-danger:focus, .btn-danger:active, .btn-danger.active, .open .dropdown-toggle.btn-danger, .btn-danger:active:focus, .btn-danger:active:hover, .btn-danger.active:hover, .btn-danger.active:focus {
   background-color: #ec4758;
   border-color: #ec4758;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 157, ../../sass/_buttons.sass */
 .btn-danger:active, .btn-danger.active, .open .dropdown-toggle.btn-danger {
-  background-image: none;
-}
+  background-image: none; }
 
-/* line 161, ../../sass/_buttons.sass */
 .btn-danger.disabled, .btn-danger.disabled:hover, .btn-danger.disabled:focus, .btn-danger.disabled:active, .btn-danger.disabled.active, .btn-danger[disabled], .btn-danger[disabled]:hover, .btn-danger[disabled]:focus, .btn-danger[disabled]:active, .btn-danger.active[disabled], fieldset[disabled] .btn-danger, fieldset[disabled] .btn-danger:hover, fieldset[disabled] .btn-danger:focus, fieldset[disabled] .btn-danger:active, fieldset[disabled] .btn-danger.active {
   background-color: #ef6776;
-  border-color: #ef6776;
-}
+  border-color: #ef6776; }
 
-/* line 166, ../../sass/_buttons.sass */
 .btn-link {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 170, ../../sass/_buttons.sass */
 .btn-link:hover, .btn-link:focus, .btn-link:active, .btn-link.active, .open .dropdown-toggle.btn-link {
   color: #1ab394;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
-/* line 175, ../../sass/_buttons.sass */
 .btn-link:active, .btn-link.active, .open .dropdown-toggle.btn-link {
-  background-image: none;
-}
+  background-image: none; }
 
-/* line 179, ../../sass/_buttons.sass */
 .btn-link.disabled, .btn-link.disabled:hover, .btn-link.disabled:focus, .btn-link.disabled:active, .btn-link.disabled.active, .btn-link[disabled], .btn-link[disabled]:hover, .btn-link[disabled]:focus, .btn-link[disabled]:active, .btn-link.active[disabled], fieldset[disabled] .btn-link, fieldset[disabled] .btn-link:hover, fieldset[disabled] .btn-link:focus, fieldset[disabled] .btn-link:active, fieldset[disabled] .btn-link.active {
-  color: #cacaca;
-}
+  color: #cacaca; }
 
-/* line 183, ../../sass/_buttons.sass */
 .btn-white {
   color: inherit;
   background: white;
-  border: 1px solid #e7eaec;
-}
+  border: 1px solid #e7eaec; }
 
-/* line 189, ../../sass/_buttons.sass */
 .btn-white:hover, .btn-white:focus, .btn-white:active, .btn-white.active, .open .dropdown-toggle.btn-white, .btn-white:active:focus, .btn-white:active:hover, .btn-white.active:hover, .btn-white.active:focus {
   color: inherit;
-  border: 1px solid #d2d2d2;
-}
+  border: 1px solid #d2d2d2; }
 
-/* line 194, ../../sass/_buttons.sass */
 .btn-white:active, .btn-white.active {
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15) inset;
-}
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15) inset; }
 
-/* line 198, ../../sass/_buttons.sass */
 .btn-white:active, .btn-white.active, .open .dropdown-toggle.btn-white {
-  background-image: none;
-}
+  background-image: none; }
 
-/* line 202, ../../sass/_buttons.sass */
 .btn-white.disabled, .btn-white.disabled:hover, .btn-white.disabled:focus, .btn-white.disabled:active, .btn-white.disabled.active, .btn-white[disabled], .btn-white[disabled]:hover, .btn-white[disabled]:focus, .btn-white[disabled]:active, .btn-white.active[disabled], fieldset[disabled] .btn-white, fieldset[disabled] .btn-white:hover, fieldset[disabled] .btn-white:focus, fieldset[disabled] .btn-white:active, fieldset[disabled] .btn-white.active {
-  color: #cacaca;
-}
+  color: #cacaca; }
 
-/* line 206, ../../sass/_buttons.sass */
 .form-control, .form-control:focus, .has-error .form-control:focus, .has-success .form-control:focus, .has-warning .form-control:focus, .navbar-collapse, .navbar-form, .navbar-form-custom .form-control:focus, .navbar-form-custom .form-control:hover, .open .btn.dropdown-toggle, .panel, .popover, .progress, .progress-bar {
-  box-shadow: none;
-}
+  box-shadow: none; }
 
-/* line 210, ../../sass/_buttons.sass */
 .btn-outline {
   color: inherit;
   background-color: transparent;
-  transition: all 0.5s;
-}
+  transition: all 0.5s; }
 
-/* line 216, ../../sass/_buttons.sass */
 .btn-rounded {
-  border-radius: 50px;
-}
+  border-radius: 50px; }
 
-/* line 220, ../../sass/_buttons.sass */
 .btn-large-dim {
   width: 90px;
   height: 90px;
-  font-size: 42px;
-}
+  font-size: 42px; }
 
-/* line 226, ../../sass/_buttons.sass */
 button.dim {
   display: inline-block;
   text-decoration: none;
@@ -1151,111 +764,73 @@ button.dim {
   cursor: pointer;
   border-radius: 5px;
   font-weight: 600;
-  margin-bottom: 20px !important;
-}
+  margin-bottom: 20px !important; }
 
-/* line 240, ../../sass/_buttons.sass */
 button.dim:active {
-  top: 3px;
-}
+  top: 3px; }
 
-/* line 244, ../../sass/_buttons.sass */
 button.btn-primary.dim {
-  box-shadow: inset 0 0 0 #16987e, 0 5px 0 0 #16987e, 0 10px 5px #999;
-}
+  box-shadow: inset 0 0 0 #16987e, 0 5px 0 0 #16987e, 0 10px 5px #999; }
 
-/* line 248, ../../sass/_buttons.sass */
 button.btn-primary.dim:active {
-  box-shadow: inset 0 0 0 #16987e, 0 2px 0 0 #16987e, 0 5px 3px #999;
-}
+  box-shadow: inset 0 0 0 #16987e, 0 2px 0 0 #16987e, 0 5px 3px #999; }
 
-/* line 252, ../../sass/_buttons.sass */
 button.btn-default.dim {
-  box-shadow: inset 0 0 0 #b3b3b3, 0 5px 0 0 #b3b3b3, 0 10px 5px #999;
-}
+  box-shadow: inset 0 0 0 #b3b3b3, 0 5px 0 0 #b3b3b3, 0 10px 5px #999; }
 
-/* line 256, ../../sass/_buttons.sass */
 button.btn-default.dim:active {
-  box-shadow: inset 0 0 0 #b3b3b3, 0 2px 0 0 #b3b3b3, 0 5px 3px #999;
-}
+  box-shadow: inset 0 0 0 #b3b3b3, 0 2px 0 0 #b3b3b3, 0 5px 3px #999; }
 
-/* line 260, ../../sass/_buttons.sass */
 button.btn-warning.dim {
-  box-shadow: inset 0 0 0 #f79d3c, 0 5px 0 0 #f79d3c, 0 10px 5px #999;
-}
+  box-shadow: inset 0 0 0 #f79d3c, 0 5px 0 0 #f79d3c, 0 10px 5px #999; }
 
-/* line 264, ../../sass/_buttons.sass */
 button.btn-warning.dim:active {
-  box-shadow: inset 0 0 0 #f79d3c, 0 2px 0 0 #f79d3c, 0 5px 3px #999;
-}
+  box-shadow: inset 0 0 0 #f79d3c, 0 2px 0 0 #f79d3c, 0 5px 3px #999; }
 
-/* line 268, ../../sass/_buttons.sass */
 button.btn-info.dim {
-  box-shadow: inset 0 0 0 #1eacae, 0 5px 0 0 #1eacae, 0 10px 5px #999;
-}
+  box-shadow: inset 0 0 0 #1eacae, 0 5px 0 0 #1eacae, 0 10px 5px #999; }
 
-/* line 272, ../../sass/_buttons.sass */
 button.btn-info.dim:active {
-  box-shadow: inset 0 0 0 #1eacae, 0 2px 0 0 #1eacae, 0 5px 3px #999;
-}
+  box-shadow: inset 0 0 0 #1eacae, 0 2px 0 0 #1eacae, 0 5px 3px #999; }
 
-/* line 276, ../../sass/_buttons.sass */
 button.btn-success.dim {
-  box-shadow: inset 0 0 0 #1872ab, 0 5px 0 0 #1872ab, 0 10px 5px #999;
-}
+  box-shadow: inset 0 0 0 #1872ab, 0 5px 0 0 #1872ab, 0 10px 5px #999; }
 
-/* line 280, ../../sass/_buttons.sass */
 button.btn-success.dim:active {
-  box-shadow: inset 0 0 0 #1872ab, 0 2px 0 0 #1872ab, 0 5px 3px #999;
-}
+  box-shadow: inset 0 0 0 #1872ab, 0 2px 0 0 #1872ab, 0 5px 3px #999; }
 
-/* line 284, ../../sass/_buttons.sass */
 button.btn-danger.dim {
-  box-shadow: inset 0 0 0 #ea394c, 0 5px 0 0 #ea394c, 0 10px 5px #999;
-}
+  box-shadow: inset 0 0 0 #ea394c, 0 5px 0 0 #ea394c, 0 10px 5px #999; }
 
-/* line 288, ../../sass/_buttons.sass */
 button.btn-danger.dim:active {
-  box-shadow: inset 0 0 0 #ea394c, 0 2px 0 0 #ea394c, 0 5px 3px #999;
-}
+  box-shadow: inset 0 0 0 #ea394c, 0 2px 0 0 #ea394c, 0 5px 3px #999; }
 
-/* line 292, ../../sass/_buttons.sass */
 button.dim:before {
   font-size: 50px;
   line-height: 1em;
   font-weight: normal;
   color: #fff;
   display: block;
-  padding-top: 10px;
-}
+  padding-top: 10px; }
 
-/* line 302, ../../sass/_buttons.sass */
 button.dim:active:before {
   top: 7px;
-  font-size: 50px;
-}
+  font-size: 50px; }
 
-/* line 307, ../../sass/_buttons.sass */
 .btn:focus {
-  outline: none !important;
-}
+  outline: none !important; }
 
-/* line 1, ../../sass/_badges_labels.sass */
 .label {
   background-color: #D1DADE;
   color: #5E5E5E;
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 600;
   padding: 3px 8px;
-  text-shadow: none;
-}
+  text-shadow: none; }
 
-/* line 9, ../../sass/_badges_labels.sass */
 .nav .label, .ibox .label {
-  font-size: 10px;
-}
+  font-size: 10px; }
 
-/* line 12, ../../sass/_badges_labels.sass */
 .badge {
   background-color: #D1DADE;
   color: #5E5E5E;
@@ -1265,98 +840,70 @@ button.dim:active:before {
   padding-bottom: 4px;
   padding-left: 6px;
   padding-right: 6px;
-  text-shadow: none;
-}
+  text-shadow: none; }
 
-/* line 24, ../../sass/_badges_labels.sass */
 .label-primary, .badge-primary {
   background-color: #1ab394;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 29, ../../sass/_badges_labels.sass */
 .label-success, .badge-success {
   background-color: #1c84c6;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 34, ../../sass/_badges_labels.sass */
 .label-warning, .badge-warning {
   background-color: #f8ac59;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 39, ../../sass/_badges_labels.sass */
 .label-warning-light, .badge-warning-light {
   background-color: #f8ac59;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 44, ../../sass/_badges_labels.sass */
 .label-danger, .badge-danger {
   background-color: #ED5565;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 49, ../../sass/_badges_labels.sass */
 .label-info, .badge-info {
   background-color: #23c6c8;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 54, ../../sass/_badges_labels.sass */
 .label-inverse, .badge-inverse {
   background-color: #262626;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 59, ../../sass/_badges_labels.sass */
 .label-white, .badge-white {
   background-color: #FFFFFF;
-  color: #5E5E5E;
-}
+  color: #5E5E5E; }
 
-/* line 64, ../../sass/_badges_labels.sass */
 .label-white, .badge-disable {
   background-color: #2A2E36;
-  color: #8B91A0;
-}
+  color: #8B91A0; }
 
 /* TOOGLE SWICH */
-/* line 3, ../../sass/_elements.sass */
 .onoffswitch {
   position: relative;
   width: 64px;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-}
+  -ms-user-select: none; }
 
-/* line 11, ../../sass/_elements.sass */
 .onoffswitch-checkbox {
-  display: none;
-}
+  display: none; }
 
-/* line 15, ../../sass/_elements.sass */
 .onoffswitch-label {
   display: block;
   overflow: hidden;
   cursor: pointer;
   border: 2px solid #1ab394;
-  border-radius: 2px;
-}
+  border-radius: 2px; }
 
-/* line 23, ../../sass/_elements.sass */
 .onoffswitch-inner {
   width: 200%;
   margin-left: -100%;
   -moz-transition: margin 0.3s ease-in 0s;
   -webkit-transition: margin 0.3s ease-in 0s;
   -o-transition: margin 0.3s ease-in 0s;
-  transition: margin 0.3s ease-in 0s;
-}
+  transition: margin 0.3s ease-in 0s; }
 
-/* line 32, ../../sass/_elements.sass */
 .onoffswitch-inner:before, .onoffswitch-inner:after {
   float: left;
   width: 50%;
@@ -1369,27 +916,21 @@ button.dim:active:before {
   font-weight: bold;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
-/* line 47, ../../sass/_elements.sass */
 .onoffswitch-inner:before {
   content: "ON";
   padding-left: 10px;
   background-color: #1ab394;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 54, ../../sass/_elements.sass */
 .onoffswitch-inner:after {
   content: "OFF";
   padding-right: 10px;
   background-color: #FFFFFF;
   color: #999999;
-  text-align: right;
-}
+  text-align: right; }
 
-/* line 62, ../../sass/_elements.sass */
 .onoffswitch-switch {
   width: 20px;
   margin: 0;
@@ -1403,31 +944,21 @@ button.dim:active:before {
   -moz-transition: all 0.3s ease-in 0s;
   -webkit-transition: all 0.3s ease-in 0s;
   -o-transition: all 0.3s ease-in 0s;
-  transition: all 0.3s ease-in 0s;
-}
+  transition: all 0.3s ease-in 0s; }
 
-/* line 78, ../../sass/_elements.sass */
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-inner {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
-/* line 82, ../../sass/_elements.sass */
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-switch {
-  right: 0;
-}
+  right: 0; }
 
-/* line 85, ../../sass/_elements.sass */
 .onoffswitch-checkbox:disabled + .onoffswitch-label .onoffswitch-inner:before {
-  background-color: #919191;
-}
+  background-color: #919191; }
 
-/* line 89, ../../sass/_elements.sass */
 .onoffswitch-checkbox:disabled + .onoffswitch-label, .onoffswitch-checkbox:disabled + .onoffswitch-label .onoffswitch-switch {
-  border-color: #919191;
-}
+  border-color: #919191; }
 
 /* CHOSEN PLUGIN */
-/* line 95, ../../sass/_elements.sass */
 .chosen-container-single .chosen-single {
   background: #ffffff;
   box-shadow: none;
@@ -1441,10 +972,8 @@ button.dim:active:before {
   overflow: hidden;
   padding: 4px 12px;
   position: relative;
-  width: 100%;
-}
+  width: 100%; }
 
-/* line 111, ../../sass/_elements.sass */
 .chosen-container-multi .chosen-choices li.search-choice {
   background: #f1f1f1;
   border: 1px solid #ededed;
@@ -1455,27 +984,21 @@ button.dim:active:before {
   line-height: 13px;
   margin: 3px 0 3px 5px;
   padding: 3px 20px 3px 5px;
-  position: relative;
-}
+  position: relative; }
 
 /* Tags Input Plugin */
-/* line 126, ../../sass/_elements.sass */
 .bootstrap-tagsinput {
   border: 1px solid #e5e6e7;
-  box-shadow: none;
-}
+  box-shadow: none; }
 
 /* PAGINATIN */
-/* line 133, ../../sass/_elements.sass */
 .pagination > .active > a, .pagination > .active > span, .pagination > .active > a:hover, .pagination > .active > span:hover, .pagination > .active > a:focus, .pagination > .active > span:focus {
   background-color: #f4f4f4;
   border-color: #DDDDDD;
   color: inherit;
   cursor: default;
-  z-index: 2;
-}
+  z-index: 2; }
 
-/* line 141, ../../sass/_elements.sass */
 .pagination > li > a, .pagination > li > span {
   background-color: #FFFFFF;
   border: 1px solid #DDDDDD;
@@ -1485,93 +1008,65 @@ button.dim:active:before {
   margin-left: -1px;
   padding: 4px 10px;
   position: relative;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
 /* TOOLTIPS */
-/* line 155, ../../sass/_elements.sass */
 .tooltip-inner {
-  background-color: #2F4050;
-}
+  background-color: #2F4050; }
 
-/* line 159, ../../sass/_elements.sass */
 .tooltip.top .tooltip-arrow {
-  border-top-color: #2F4050;
-}
+  border-top-color: #2F4050; }
 
-/* line 163, ../../sass/_elements.sass */
 .tooltip.right .tooltip-arrow {
-  border-right-color: #2F4050;
-}
+  border-right-color: #2F4050; }
 
-/* line 167, ../../sass/_elements.sass */
 .tooltip.bottom .tooltip-arrow {
-  border-bottom-color: #2F4050;
-}
+  border-bottom-color: #2F4050; }
 
-/* line 171, ../../sass/_elements.sass */
 .tooltip.left .tooltip-arrow {
-  border-left-color: #2F4050;
-}
+  border-left-color: #2F4050; }
 
 /* EASY PIE CHART */
-/* line 177, ../../sass/_elements.sass */
 .easypiechart {
   position: relative;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 182, ../../sass/_elements.sass */
 .easypiechart .h2 {
   margin-left: 10px;
   margin-top: 10px;
-  display: inline-block;
-}
+  display: inline-block; }
 
-/* line 188, ../../sass/_elements.sass */
 .easypiechart canvas {
   top: 0;
-  left: 0;
-}
+  left: 0; }
 
-/* line 193, ../../sass/_elements.sass */
 .easypiechart .easypie-text {
   line-height: 1;
   position: absolute;
   top: 33px;
   width: 100%;
-  z-index: 1;
-}
+  z-index: 1; }
 
-/* line 201, ../../sass/_elements.sass */
 .easypiechart img {
-  margin-top: -4px;
-}
+  margin-top: -4px; }
 
-/* line 205, ../../sass/_elements.sass */
 .jqstooltip {
   -webkit-box-sizing: content-box;
   -moz-box-sizing: content-box;
-  box-sizing: content-box;
-}
+  box-sizing: content-box; }
 
 /* FULLCALENDAR */
-/* line 213, ../../sass/_elements.sass */
 .fc-state-default {
   background-color: #ffffff;
   background-image: none;
   background-repeat: repeat-x;
   box-shadow: none;
   color: #333333;
-  text-shadow: none;
-}
+  text-shadow: none; }
 
-/* line 222, ../../sass/_elements.sass */
 .fc-state-default {
-  border: 1px solid;
-}
+  border: 1px solid; }
 
-/* line 226, ../../sass/_elements.sass */
 .fc-button {
   color: inherit;
   border: 1px solid #e7eaec;
@@ -1582,116 +1077,78 @@ button.dim:active:before {
   overflow: hidden;
   padding: 0 0.6em;
   position: relative;
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
-/* line 239, ../../sass/_elements.sass */
 .fc-state-active {
   background-color: #1ab394;
   border-color: #1ab394;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 245, ../../sass/_elements.sass */
 .fc-header-title h2 {
   font-size: 16px;
   font-weight: 600;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 251, ../../sass/_elements.sass */
 .fc-content .fc-widget-header, .fc-content .fc-widget-content {
   border-color: #e7eaec;
-  font-weight: normal;
-}
+  font-weight: normal; }
 
-/* line 256, ../../sass/_elements.sass */
 .fc-border-separate tbody {
-  background-color: #F8F8F8;
-}
+  background-color: #F8F8F8; }
 
-/* line 260, ../../sass/_elements.sass */
 .fc-state-highlight {
-  background: none repeat scroll 0 0 #FCF8E3;
-}
+  background: none repeat scroll 0 0 #FCF8E3; }
 
-/* line 264, ../../sass/_elements.sass */
 .external-event {
   padding: 5px 10px;
   border-radius: 2px;
   cursor: pointer;
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
-/* line 271, ../../sass/_elements.sass */
 .fc-ltr .fc-event-hori.fc-event-end, .fc-rtl .fc-event-hori.fc-event-start {
-  border-radius: 2px;
-}
+  border-radius: 2px; }
 
-/* line 275, ../../sass/_elements.sass */
 .fc-event,
 .fc-agenda .fc-event-time,
 .fc-event a {
   padding: 4px 6px;
   background-color: #1ab394;
-  border-color: #1ab394;
-}
+  border-color: #1ab394; }
 
-/* line 283, ../../sass/_elements.sass */
 .fc-event-time, .fc-event-title {
   color: #717171;
-  padding: 0 1px;
-}
+  padding: 0 1px; }
 
-/* line 288, ../../sass/_elements.sass */
 .ui-calendar .fc-event-time, .ui-calendar .fc-event-title {
-  color: #fff;
-}
+  color: #fff; }
 
 /* Chat */
-/* line 293, ../../sass/_elements.sass */
 .chat-activity-list .chat-element {
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 297, ../../sass/_elements.sass */
 .chat-element:first-child {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 301, ../../sass/_elements.sass */
 .chat-element {
-  padding-bottom: 15px;
-}
+  padding-bottom: 15px; }
 
-/* line 305, ../../sass/_elements.sass */
 .chat-element, .chat-element .media {
-  margin-top: 15px;
-}
+  margin-top: 15px; }
 
-/* line 309, ../../sass/_elements.sass */
 .chat-element, .media-body {
-  overflow: hidden;
-}
+  overflow: hidden; }
 
-/* line 313, ../../sass/_elements.sass */
 .chat-element .media-body {
   display: block;
-  width: auto;
-}
+  width: auto; }
 
-/* line 318, ../../sass/_elements.sass */
 .chat-element > .pull-left {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 322, ../../sass/_elements.sass */
 .chat-element img.img-circle, .dropdown-messages-box img.img-circle {
   width: 38px;
-  height: 38px;
-}
+  height: 38px; }
 
-/* line 327, ../../sass/_elements.sass */
 .chat-element .well {
   border: 1px solid #e7eaec;
   box-shadow: none;
@@ -1699,205 +1156,143 @@ button.dim:active:before {
   margin-bottom: 5px;
   padding: 10px 20px;
   font-size: 11px;
-  line-height: 16px;
-}
+  line-height: 16px; }
 
-/* line 337, ../../sass/_elements.sass */
 .chat-element .actions {
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 341, ../../sass/_elements.sass */
 .chat-element .photos {
-  margin: 10px 0;
-}
+  margin: 10px 0; }
 
-/* line 346, ../../sass/_elements.sass */
 .right.chat-element > .pull-right {
-  margin-left: 10px;
-}
+  margin-left: 10px; }
 
-/* line 350, ../../sass/_elements.sass */
 .chat-photo {
   max-height: 180px;
   border-radius: 4px;
   overflow: hidden;
   margin-right: 10px;
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 358, ../../sass/_elements.sass */
 .chat {
   margin: 0;
   padding: 0;
-  list-style: none;
-}
+  list-style: none; }
 
-/* line 364, ../../sass/_elements.sass */
 .chat li {
   margin-bottom: 10px;
   padding-bottom: 5px;
-  border-bottom: 1px dotted #B3A9A9;
-}
+  border-bottom: 1px dotted #B3A9A9; }
 
-/* line 370, ../../sass/_elements.sass */
 .chat li.left .chat-body {
-  margin-left: 60px;
-}
+  margin-left: 60px; }
 
-/* line 374, ../../sass/_elements.sass */
 .chat li.right .chat-body {
-  margin-right: 60px;
-}
+  margin-right: 60px; }
 
-/* line 378, ../../sass/_elements.sass */
 .chat li .chat-body p {
   margin: 0;
-  color: #777777;
-}
+  color: #777777; }
 
-/* line 383, ../../sass/_elements.sass */
 .panel .slidedown .glyphicon,
 .chat .glyphicon {
-  margin-right: 5px;
-}
+  margin-right: 5px; }
 
-/* line 388, ../../sass/_elements.sass */
 .chat-panel .panel-body {
   height: 350px;
-  overflow-y: scroll;
-}
+  overflow-y: scroll; }
 
 /* LIST GROUP */
-/* line 395, ../../sass/_elements.sass */
 a.list-group-item.active, a.list-group-item.active:hover, a.list-group-item.active:focus {
   background-color: #1ab394;
   border-color: #1ab394;
   color: #FFFFFF;
-  z-index: 2;
-}
+  z-index: 2; }
 
-/* line 402, ../../sass/_elements.sass */
 .list-group-item-heading {
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 406, ../../sass/_elements.sass */
 .list-group-item-text {
   margin: 0 0 10px;
   color: inherit;
   font-size: 12px;
-  line-height: inherit;
-}
+  line-height: inherit; }
 
-/* line 413, ../../sass/_elements.sass */
 .no-padding .list-group-item {
   border-left: none;
   border-right: none;
-  border-bottom: none;
-}
+  border-bottom: none; }
 
-/* line 419, ../../sass/_elements.sass */
 .no-padding .list-group-item:first-child {
   border-left: none;
   border-right: none;
   border-bottom: none;
-  border-top: none;
-}
+  border-top: none; }
 
-/* line 426, ../../sass/_elements.sass */
 .no-padding .list-group {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 430, ../../sass/_elements.sass */
 .list-group-item {
   background-color: inherit;
   border: 1px solid #e7eaec;
   display: block;
   margin-bottom: -1px;
   padding: 10px 15px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 439, ../../sass/_elements.sass */
 .elements-list .list-group-item {
   border-left: none;
   border-right: none;
-  padding: 15px 25px;
-}
+  padding: 15px 25px; }
 
-/* line 446, ../../sass/_elements.sass */
 .elements-list .list-group-item:first-child {
   border-left: none;
   border-right: none;
-  border-top: none !important;
-}
+  border-top: none !important; }
 
-/* line 452, ../../sass/_elements.sass */
 .elements-list .list-group {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 456, ../../sass/_elements.sass */
 .elements-list a {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 460, ../../sass/_elements.sass */
 .elements-list .list-group-item.active,
 .elements-list .list-group-item:hover {
   background: #f3f3f4;
   color: inherit;
   border-color: #e7eaec;
-  border-radius: 0;
-}
+  border-radius: 0; }
 
-/* line 468, ../../sass/_elements.sass */
 .elements-list li.active {
-  transition: none;
-}
+  transition: none; }
 
-/* line 472, ../../sass/_elements.sass */
 .element-detail-box {
-  padding: 25px;
-}
+  padding: 25px; }
 
 /* FLOT CHART  */
-/* line 478, ../../sass/_elements.sass */
 .flot-chart {
   display: block;
-  height: 200px;
-}
+  height: 200px; }
 
-/* line 483, ../../sass/_elements.sass */
 .widget .flot-chart.dashboard-chart {
   display: block;
   height: 120px;
-  margin-top: 40px;
-}
+  margin-top: 40px; }
 
-/* line 489, ../../sass/_elements.sass */
 .flot-chart.dashboard-chart {
   display: block;
   height: 180px;
-  margin-top: 40px;
-}
+  margin-top: 40px; }
 
-/* line 495, ../../sass/_elements.sass */
 .flot-chart-content {
   width: 100%;
-  height: 100%;
-}
+  height: 100%; }
 
-/* line 500, ../../sass/_elements.sass */
 .flot-chart-pie-content {
   width: 200px;
   height: 200px;
-  margin: auto;
-}
+  margin: auto; }
 
-/* line 506, ../../sass/_elements.sass */
 .jqstooltip {
   position: absolute;
   display: block;
@@ -1912,153 +1307,100 @@ a.list-group-item.active, a.list-group-item.active:hover, a.list-group-item.acti
   z-index: 10000;
   padding: 5px 5px 5px 5px;
   min-height: 22px;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 523, ../../sass/_elements.sass */
 .jqsfield {
   color: white;
-  text-align: left;
-}
+  text-align: left; }
 
-/* line 528, ../../sass/_elements.sass */
 .fh-150 {
-  height: 150px;
-}
+  height: 150px; }
 
-/* line 532, ../../sass/_elements.sass */
 .fh-200 {
-  height: 200px;
-}
+  height: 200px; }
 
-/* line 536, ../../sass/_elements.sass */
 .h-150 {
-  min-height: 150px;
-}
+  min-height: 150px; }
 
-/* line 540, ../../sass/_elements.sass */
 .h-200 {
-  min-height: 200px;
-}
+  min-height: 200px; }
 
-/* line 543, ../../sass/_elements.sass */
 .h-300 {
-  min-height: 300px;
-}
+  min-height: 300px; }
 
-/* line 547, ../../sass/_elements.sass */
 .w-150 {
-  min-width: 150px;
-}
+  min-width: 150px; }
 
-/* line 550, ../../sass/_elements.sass */
 .w-200 {
-  min-width: 200px;
-}
+  min-width: 200px; }
 
-/* line 554, ../../sass/_elements.sass */
 .w-300 {
-  min-width: 300px;
-}
+  min-width: 300px; }
 
-/* line 558, ../../sass/_elements.sass */
 .legendLabel {
-  padding-left: 5px;
-}
+  padding-left: 5px; }
 
-/* line 562, ../../sass/_elements.sass */
 .stat-list li:first-child {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 566, ../../sass/_elements.sass */
 .stat-list {
   list-style: none;
   padding: 0;
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 572, ../../sass/_elements.sass */
 .stat-percent {
-  float: right;
-}
+  float: right; }
 
-/* line 576, ../../sass/_elements.sass */
 .stat-list li {
   margin-top: 15px;
-  position: relative;
-}
+  position: relative; }
 
 /* DATATABLES */
-/* line 583, ../../sass/_elements.sass */
 table.dataTable thead .sorting,
 table.dataTable thead .sorting_asc:after,
 table.dataTable thead .sorting_desc,
 table.dataTable thead .sorting_asc_disabled,
 table.dataTable thead .sorting_desc_disabled {
-  background: transparent;
-}
+  background: transparent; }
 
-/* line 591, ../../sass/_elements.sass */
 .dataTables_wrapper {
-  padding-bottom: 30px;
-}
+  padding-bottom: 30px; }
 
-/* line 595, ../../sass/_elements.sass */
 .dataTables_length {
-  float: left;
-}
+  float: left; }
 
-/* line 599, ../../sass/_elements.sass */
 .dataTables_filter label {
-  margin-right: 5px;
-}
+  margin-right: 5px; }
 
-/* line 603, ../../sass/_elements.sass */
 .html5buttons {
-  float: right;
-}
+  float: right; }
 
-/* line 607, ../../sass/_elements.sass */
 .html5buttons a {
   border: 1px solid #e7eaec;
   background: #fff;
   color: #676a6c;
   box-shadow: none;
   padding: 6px 8px;
-  font-size: 12px;
-}
-/* line 615, ../../sass/_elements.sass */
-.html5buttons a:hover, .html5buttons a:focus:active {
-  background-color: #eee;
-  color: inherit;
-  border-color: #d2d2d2;
-}
+  font-size: 12px; }
+  .html5buttons a:hover, .html5buttons a:focus:active {
+    background-color: #eee;
+    color: inherit;
+    border-color: #d2d2d2; }
 
-/* line 622, ../../sass/_elements.sass */
 div.dt-button-info {
-  z-index: 100;
-}
+  z-index: 100; }
 
 @media (max-width: 768px) {
-  /* line 627, ../../sass/_elements.sass */
   .html5buttons {
     float: none;
-    margin-top: 10px;
-  }
+    margin-top: 10px; }
 
-  /* line 632, ../../sass/_elements.sass */
   .dataTables_length {
-    float: none;
-  }
-}
+    float: none; } }
 /* CIRCLE */
-/* line 639, ../../sass/_elements.sass */
 .img-circle {
-  border-radius: 50%;
-}
+  border-radius: 50%; }
 
-/* line 643, ../../sass/_elements.sass */
 .btn-circle {
   width: 30px;
   height: 30px;
@@ -2066,111 +1408,83 @@ div.dt-button-info {
   border-radius: 15px;
   text-align: center;
   font-size: 12px;
-  line-height: 1.42857;
-}
+  line-height: 1.42857; }
 
-/* line 653, ../../sass/_elements.sass */
 .btn-circle.btn-lg {
   width: 50px;
   height: 50px;
   padding: 10px 16px;
   border-radius: 25px;
   font-size: 18px;
-  line-height: 1.33;
-}
+  line-height: 1.33; }
 
-/* line 662, ../../sass/_elements.sass */
 .btn-circle.btn-xl {
   width: 70px;
   height: 70px;
   padding: 10px 16px;
   border-radius: 35px;
   font-size: 24px;
-  line-height: 1.33;
-}
+  line-height: 1.33; }
 
-/* line 671, ../../sass/_elements.sass */
 .show-grid [class^="col-"] {
   padding-top: 10px;
   padding-bottom: 10px;
   border: 1px solid #ddd;
-  background-color: #eee !important;
-}
+  background-color: #eee !important; }
 
-/* line 678, ../../sass/_elements.sass */
 .show-grid {
-  margin: 15px 0;
-}
+  margin: 15px 0; }
 
 /* ANIMATION */
-/* line 684, ../../sass/_elements.sass */
 .css-animation-box h1 {
-  font-size: 44px;
-}
+  font-size: 44px; }
 
-/* line 688, ../../sass/_elements.sass */
 .animation-efect-links a {
   padding: 4px 6px;
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 693, ../../sass/_elements.sass */
 #animation_box {
   background-color: #f9f8f8;
   border-radius: 16px;
   width: 80%;
   margin: 0 auto;
-  padding-top: 80px;
-}
+  padding-top: 80px; }
 
-/* line 701, ../../sass/_elements.sass */
 .animation-text-box {
   position: absolute;
   margin-top: 40px;
   left: 50%;
   margin-left: -100px;
-  width: 200px;
-}
+  width: 200px; }
 
-/* line 709, ../../sass/_elements.sass */
 .animation-text-info {
   position: absolute;
   margin-top: -60px;
   left: 50%;
   margin-left: -100px;
   width: 200px;
-  font-size: 10px;
-}
+  font-size: 10px; }
 
-/* line 718, ../../sass/_elements.sass */
 .animation-text-box h2 {
   font-size: 54px;
   font-weight: 600;
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
-/* line 724, ../../sass/_elements.sass */
 .animation-text-box p {
   font-size: 12px;
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
 /* PEACE */
-/* line 731, ../../sass/_elements.sass */
 .pace {
   -webkit-pointer-events: none;
   pointer-events: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-  user-select: none;
-}
+  user-select: none; }
 
-/* line 740, ../../sass/_elements.sass */
 .pace-inactive {
-  display: none;
-}
+  display: none; }
 
-/* line 744, ../../sass/_elements.sass */
 .pace .pace-progress {
   background: #1ab394;
   position: fixed;
@@ -2178,77 +1492,53 @@ div.dt-button-info {
   top: 0;
   right: 100%;
   width: 100%;
-  height: 2px;
-}
+  height: 2px; }
 
-/* line 754, ../../sass/_elements.sass */
 .pace-inactive {
-  display: none;
-}
+  display: none; }
 
 /* WIDGETS */
-/* line 760, ../../sass/_elements.sass */
 .widget {
   border-radius: 5px;
   padding: 15px 20px;
   margin-bottom: 10px;
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 767, ../../sass/_elements.sass */
 .widget.style1 h2 {
-  font-size: 30px;
-}
+  font-size: 30px; }
 
-/* line 771, ../../sass/_elements.sass */
 .widget h2, .widget h3 {
   margin-top: 5px;
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 776, ../../sass/_elements.sass */
 .widget-text-box {
   padding: 20px;
   border: 1px solid #e7eaec;
-  background: #ffffff;
-}
+  background: #ffffff; }
 
-/* line 782, ../../sass/_elements.sass */
 .widget-head-color-box {
   border-radius: 5px 5px 0 0;
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 788, ../../sass/_elements.sass */
 .widget .flot-chart {
-  height: 100px;
-}
+  height: 100px; }
 
-/* line 792, ../../sass/_elements.sass */
 .vertical-align div {
   display: inline-block;
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
-/* line 797, ../../sass/_elements.sass */
 .vertical-align h2, .vertical-align h3 {
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 801, ../../sass/_elements.sass */
 .todo-list {
   list-style: none outside none;
   margin: 0;
   padding: 0;
-  font-size: 14px;
-}
+  font-size: 14px; }
 
-/* line 808, ../../sass/_elements.sass */
 .todo-list.small-list {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 812, ../../sass/_elements.sass */
 .todo-list.small-list > li {
   background: #f3f3f4;
   border-left: none;
@@ -2256,18 +1546,14 @@ div.dt-button-info {
   border-radius: 4px;
   color: inherit;
   margin-bottom: 2px;
-  padding: 6px 6px 6px 12px;
-}
+  padding: 6px 6px 6px 12px; }
 
-/* line 822, ../../sass/_elements.sass */
 .todo-list.small-list .btn-xs, .todo-list.small-list .btn-group-xs > .btn {
   border-radius: 5px;
   font-size: 10px;
   line-height: 1.5;
-  padding: 1px 2px 1px 5px;
-}
+  padding: 1px 2px 1px 5px; }
 
-/* line 829, ../../sass/_elements.sass */
 .todo-list > li {
   background: #f3f3f4;
   border-left: 6px solid #e7eaec;
@@ -2275,71 +1561,47 @@ div.dt-button-info {
   border-radius: 4px;
   color: inherit;
   margin-bottom: 2px;
-  padding: 10px;
-}
+  padding: 10px; }
 
-/* line 839, ../../sass/_elements.sass */
 .todo-list .handle {
   cursor: move;
   display: inline-block;
   font-size: 16px;
-  margin: 0 5px;
-}
+  margin: 0 5px; }
 
-/* line 846, ../../sass/_elements.sass */
 .todo-list > li .label {
   font-size: 9px;
-  margin-left: 10px;
-}
+  margin-left: 10px; }
 
-/* line 851, ../../sass/_elements.sass */
 .check-link {
-  font-size: 16px;
-}
+  font-size: 16px; }
 
-/* line 855, ../../sass/_elements.sass */
 .todo-completed {
-  text-decoration: line-through;
-}
+  text-decoration: line-through; }
 
-/* line 859, ../../sass/_elements.sass */
 .geo-statistic h1 {
   font-size: 36px;
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 864, ../../sass/_elements.sass */
 .glyphicon.fa {
-  font-family: "FontAwesome";
-}
+  font-family: "FontAwesome"; }
 
 /* INPUTS */
-/* line 869, ../../sass/_elements.sass */
 .inline {
-  display: inline-block !important;
-}
+  display: inline-block !important; }
 
-/* line 873, ../../sass/_elements.sass */
 .input-s-sm {
-  width: 120px;
-}
+  width: 120px; }
 
-/* line 877, ../../sass/_elements.sass */
 .input-s {
-  width: 200px;
-}
+  width: 200px; }
 
-/* line 881, ../../sass/_elements.sass */
 .input-s-lg {
-  width: 250px;
-}
+  width: 250px; }
 
-/* line 885, ../../sass/_elements.sass */
 .i-checks {
-  padding-left: 0;
-}
+  padding-left: 0; }
 
-/* line 889, ../../sass/_elements.sass */
 .form-control, .single-line {
   background-color: #FFFFFF;
   background-image: none;
@@ -2349,45 +1611,29 @@ div.dt-button-info {
   display: block;
   padding: 6px 12px;
   transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
-  width: 100%;
-}
+  width: 100%; }
 
-/* line 900, ../../sass/_elements.sass */
 .form-control:focus, .single-line:focus {
-  border-color: #1ab394 !important;
-}
+  border-color: #1ab394 !important; }
 
-/* line 904, ../../sass/_elements.sass */
 .has-success .form-control, .has-success .form-control:focus {
-  border-color: #1ab394;
-}
+  border-color: #1ab394; }
 
-/* line 908, ../../sass/_elements.sass */
 .has-warning .form-control, .has-warning .form-control:focus {
-  border-color: #f8ac59;
-}
+  border-color: #f8ac59; }
 
-/* line 912, ../../sass/_elements.sass */
 .has-error .form-control, .has-error .form-control:focus {
-  border-color: #ED5565;
-}
+  border-color: #ED5565; }
 
-/* line 916, ../../sass/_elements.sass */
 .has-success .control-label {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 920, ../../sass/_elements.sass */
 .has-warning .control-label {
-  color: #f8ac59;
-}
+  color: #f8ac59; }
 
-/* line 924, ../../sass/_elements.sass */
 .has-error .control-label {
-  color: #ED5565;
-}
+  color: #ED5565; }
 
-/* line 928, ../../sass/_elements.sass */
 .input-group-addon {
   background-color: #fff;
   border: 1px solid #E5E6E7;
@@ -2397,74 +1643,52 @@ div.dt-button-info {
   font-weight: 400;
   line-height: 1;
   padding: 6px 12px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 940, ../../sass/_elements.sass */
 .spinner-buttons.input-group-btn .btn-xs {
-  line-height: 1.13;
-}
+  line-height: 1.13; }
 
-/* line 944, ../../sass/_elements.sass */
 .spinner-buttons.input-group-btn {
-  width: 20%;
-}
+  width: 20%; }
 
-/* line 948, ../../sass/_elements.sass */
 .noUi-connect {
   background: none repeat scroll 0 0 #1ab394;
-  box-shadow: none;
-}
+  box-shadow: none; }
 
-/* line 953, ../../sass/_elements.sass */
 .slider_red .noUi-connect {
   background: none repeat scroll 0 0 #ED5565;
-  box-shadow: none;
-}
+  box-shadow: none; }
 
 /* UI Sortable */
-/* line 960, ../../sass/_elements.sass */
 .ui-sortable .ibox-title {
-  cursor: move;
-}
+  cursor: move; }
 
-/* line 964, ../../sass/_elements.sass */
 .ui-sortable-placeholder {
   border: 1px dashed #cecece !important;
   visibility: visible !important;
-  background: #e7eaec;
-}
+  background: #e7eaec; }
 
-/* line 970, ../../sass/_elements.sass */
 .ibox.ui-sortable-placeholder {
-  margin: 0 0 23px !important;
-}
+  margin: 0 0 23px !important; }
 
 /* SWITCHES */
-/* line 975, ../../sass/_elements.sass */
 .onoffswitch {
   position: relative;
   width: 54px;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-}
+  -ms-user-select: none; }
 
-/* line 983, ../../sass/_elements.sass */
 .onoffswitch-checkbox {
-  display: none;
-}
+  display: none; }
 
-/* line 987, ../../sass/_elements.sass */
 .onoffswitch-label {
   display: block;
   overflow: hidden;
   cursor: pointer;
   border: 2px solid #1AB394;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 995, ../../sass/_elements.sass */
 .onoffswitch-inner {
   display: block;
   width: 200%;
@@ -2472,10 +1696,8 @@ div.dt-button-info {
   -moz-transition: margin 0.3s ease-in 0s;
   -webkit-transition: margin 0.3s ease-in 0s;
   -o-transition: margin 0.3s ease-in 0s;
-  transition: margin 0.3s ease-in 0s;
-}
+  transition: margin 0.3s ease-in 0s; }
 
-/* line 1005, ../../sass/_elements.sass */
 .onoffswitch-inner:before, .onoffswitch-inner:after {
   display: block;
   float: left;
@@ -2489,27 +1711,21 @@ div.dt-button-info {
   font-weight: bold;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
-/* line 1021, ../../sass/_elements.sass */
 .onoffswitch-inner:before {
   content: "ON";
   padding-left: 7px;
   background-color: #1AB394;
-  color: #FFFFFF;
-}
+  color: #FFFFFF; }
 
-/* line 1028, ../../sass/_elements.sass */
 .onoffswitch-inner:after {
   content: "OFF";
   padding-right: 7px;
   background-color: #FFFFFF;
   color: #919191;
-  text-align: right;
-}
+  text-align: right; }
 
-/* line 1036, ../../sass/_elements.sass */
 .onoffswitch-switch {
   display: block;
   width: 18px;
@@ -2524,173 +1740,123 @@ div.dt-button-info {
   -moz-transition: all 0.3s ease-in 0s;
   -webkit-transition: all 0.3s ease-in 0s;
   -o-transition: all 0.3s ease-in 0s;
-  transition: all 0.3s ease-in 0s;
-}
+  transition: all 0.3s ease-in 0s; }
 
-/* line 1053, ../../sass/_elements.sass */
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-inner {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
-/* line 1057, ../../sass/_elements.sass */
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-switch {
-  right: 0;
-}
+  right: 0; }
 
 /* jqGrid */
-/* line 1063, ../../sass/_elements.sass */
 .ui-jqgrid {
-  -moz-box-sizing: content-box;
-}
+  -moz-box-sizing: content-box; }
 
-/* line 1067, ../../sass/_elements.sass */
 .ui-jqgrid-btable {
-  border-collapse: separate;
-}
+  border-collapse: separate; }
 
-/* line 1071, ../../sass/_elements.sass */
 .ui-jqgrid-htable {
-  border-collapse: separate;
-}
+  border-collapse: separate; }
 
-/* line 1075, ../../sass/_elements.sass */
 .ui-jqgrid-titlebar {
   height: 40px;
   line-height: 15px;
   color: #676a6c;
   background-color: #F9F9F9;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-}
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5); }
 
-/* line 1083, ../../sass/_elements.sass */
 .ui-jqgrid .ui-jqgrid-title {
   float: left;
-  margin: 1.1em 1em 0.2em;
-}
+  margin: 1.1em 1em 0.2em; }
 
-/* line 1088, ../../sass/_elements.sass */
 .ui-jqgrid .ui-jqgrid-titlebar {
   position: relative;
   border-left: 0 solid;
   border-right: 0 solid;
-  border-top: 0 solid;
-}
+  border-top: 0 solid; }
 
-/* line 1095, ../../sass/_elements.sass */
 .ui-widget-header {
   background: none;
   background-image: none;
   background-color: #f5f5f6;
   text-transform: uppercase;
   border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
+  border-top-right-radius: 0; }
 
-/* line 1104, ../../sass/_elements.sass */
 .ui-jqgrid tr.ui-row-ltr td {
   border-right-color: inherit;
   border-right-style: solid;
   border-right-width: 1px;
   text-align: left;
   border-color: #DDDDDD;
-  background-color: inherit;
-}
+  background-color: inherit; }
 
-/* line 1113, ../../sass/_elements.sass */
 .ui-search-toolbar input[type="text"] {
   font-size: 12px;
   height: 15px;
   border: 1px solid #CCCCCC;
-  border-radius: 0;
-}
+  border-radius: 0; }
 
-/* line 1120, ../../sass/_elements.sass */
 .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
   background: #F9F9F9;
   border: 1px solid #DDDDDD;
   line-height: 15px;
   font-weight: bold;
   color: #676a6c;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-}
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5); }
 
-/* line 1129, ../../sass/_elements.sass */
 .ui-widget-content {
-  box-sizing: content-box;
-}
+  box-sizing: content-box; }
 
-/* line 1133, ../../sass/_elements.sass */
 .ui-icon-triangle-1-n {
-  background-position: 1px -16px;
-}
+  background-position: 1px -16px; }
 
-/* line 1137, ../../sass/_elements.sass */
 .ui-jqgrid tr.ui-search-toolbar th {
   border-top-width: 0 !important;
   border-top-color: inherit !important;
-  border-top-style: ridge !important;
-}
+  border-top-style: ridge !important; }
 
-/* line 1143, ../../sass/_elements.sass */
 .ui-state-hover, .ui-widget-content .ui-state-hover, .ui-state-focus, .ui-widget-content .ui-state-focus, .ui-widget-header .ui-state-focus {
   background: #f5f5f5;
-  border-collapse: separate;
-}
+  border-collapse: separate; }
 
-/* line 1148, ../../sass/_elements.sass */
 .ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight {
-  background: #f2fbff;
-}
+  background: #f2fbff; }
 
-/* line 1152, ../../sass/_elements.sass */
 .ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {
   border: 1px solid #dddddd;
   background: #ffffff;
   font-weight: normal;
-  color: #212121;
-}
+  color: #212121; }
 
-/* line 1159, ../../sass/_elements.sass */
 .ui-jqgrid .ui-pg-input {
   font-size: inherit;
   width: 50px;
   border: 1px solid #CCCCCC;
-  height: 15px;
-}
+  height: 15px; }
 
-/* line 1166, ../../sass/_elements.sass */
 .ui-jqgrid .ui-pg-selbox {
   display: block;
   font-size: 1em;
   height: 25px;
   line-height: 18px;
   margin: 0;
-  width: auto;
-}
+  width: auto; }
 
-/* line 1175, ../../sass/_elements.sass */
 .ui-jqgrid .ui-pager-control {
-  position: relative;
-}
+  position: relative; }
 
-/* line 1179, ../../sass/_elements.sass */
 .ui-jqgrid .ui-jqgrid-pager {
   height: 32px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 1184, ../../sass/_elements.sass */
 .ui-pg-table .navtable .ui-corner-all {
-  border-radius: 0;
-}
+  border-radius: 0; }
 
-/* line 1188, ../../sass/_elements.sass */
 .ui-jqgrid .ui-pg-button:hover {
   padding: 1px;
-  border: 0;
-}
+  border: 0; }
 
-/* line 1193, ../../sass/_elements.sass */
 .ui-jqgrid .loading {
   position: absolute;
   top: 45%;
@@ -2704,79 +1870,51 @@ div.dt-button-info {
   font-weight: bold;
   display: none;
   border-width: 2px !important;
-  font-size: 11px;
-}
+  font-size: 11px; }
 
-/* line 1209, ../../sass/_elements.sass */
 .ui-jqgrid .form-control {
   height: 10px;
   width: auto;
   display: inline;
-  padding: 10px 12px;
-}
+  padding: 10px 12px; }
 
-/* line 1216, ../../sass/_elements.sass */
 .ui-jqgrid-pager {
-  height: 32px;
-}
+  height: 32px; }
 
-/* line 1220, ../../sass/_elements.sass */
 .ui-corner-all, .ui-corner-top, .ui-corner-left, .ui-corner-tl {
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
-/* line 1224, ../../sass/_elements.sass */
 .ui-corner-all, .ui-corner-top, .ui-corner-right, .ui-corner-tr {
-  border-top-right-radius: 0;
-}
+  border-top-right-radius: 0; }
 
-/* line 1228, ../../sass/_elements.sass */
 .ui-corner-all, .ui-corner-bottom, .ui-corner-left, .ui-corner-bl {
-  border-bottom-left-radius: 0;
-}
+  border-bottom-left-radius: 0; }
 
-/* line 1232, ../../sass/_elements.sass */
 .ui-corner-all, .ui-corner-bottom, .ui-corner-right, .ui-corner-br {
-  border-bottom-right-radius: 0;
-}
+  border-bottom-right-radius: 0; }
 
-/* line 1236, ../../sass/_elements.sass */
 .ui-widget-content {
-  border: 1px solid #ddd;
-}
+  border: 1px solid #ddd; }
 
-/* line 1240, ../../sass/_elements.sass */
 .ui-jqgrid .ui-jqgrid-titlebar {
-  padding: 0;
-}
+  padding: 0; }
 
-/* line 1244, ../../sass/_elements.sass */
 .ui-jqgrid .ui-jqgrid-titlebar {
-  border-bottom: 1px solid #ddd;
-}
+  border-bottom: 1px solid #ddd; }
 
-/* line 1248, ../../sass/_elements.sass */
 .ui-jqgrid tr.jqgrow td {
-  padding: 6px;
-}
+  padding: 6px; }
 
-/* line 1252, ../../sass/_elements.sass */
 .ui-jqdialog .ui-jqdialog-titlebar {
-  padding: 10px 10px;
-}
+  padding: 10px 10px; }
 
-/* line 1257, ../../sass/_elements.sass */
 .ui-jqdialog .ui-jqdialog-title {
-  float: none !important;
-}
+  float: none !important; }
 
-/* line 1261, ../../sass/_elements.sass */
 .ui-jqdialog > .ui-resizable-se {
-  position: absolute;
-}
+  position: absolute; }
 
 /* Nestable list */
-/* line 1267, ../../sass/_elements.sass */
 .dd {
   position: relative;
   display: block;
@@ -2784,29 +1922,21 @@ div.dt-button-info {
   padding: 0;
   list-style: none;
   font-size: 13px;
-  line-height: 20px;
-}
+  line-height: 20px; }
 
-/* line 1277, ../../sass/_elements.sass */
 .dd-list {
   display: block;
   position: relative;
   margin: 0;
   padding: 0;
-  list-style: none;
-}
+  list-style: none; }
 
-/* line 1285, ../../sass/_elements.sass */
 .dd-list .dd-list {
-  padding-left: 30px;
-}
+  padding-left: 30px; }
 
-/* line 1289, ../../sass/_elements.sass */
 .dd-collapsed .dd-list {
-  display: none;
-}
+  display: none; }
 
-/* line 1293, ../../sass/_elements.sass */
 .dd-item,
 .dd-empty,
 .dd-placeholder {
@@ -2816,10 +1946,8 @@ div.dt-button-info {
   padding: 0;
   min-height: 20px;
   font-size: 13px;
-  line-height: 20px;
-}
+  line-height: 20px; }
 
-/* line 1305, ../../sass/_elements.sass */
 .dd-handle {
   display: block;
   margin: 5px 0;
@@ -2831,22 +1959,16 @@ div.dt-button-info {
   -webkit-border-radius: 3px;
   border-radius: 3px;
   box-sizing: border-box;
-  -moz-box-sizing: border-box;
-}
+  -moz-box-sizing: border-box; }
 
-/* line 1319, ../../sass/_elements.sass */
 .dd-handle span {
-  font-weight: bold;
-}
+  font-weight: bold; }
 
-/* line 1323, ../../sass/_elements.sass */
 .dd-handle:hover {
   background: #f0f0f0;
   cursor: pointer;
-  font-weight: bold;
-}
+  font-weight: bold; }
 
-/* line 1329, ../../sass/_elements.sass */
 .dd-item > button {
   display: block;
   position: relative;
@@ -2864,43 +1986,31 @@ div.dt-button-info {
   font-size: 12px;
   line-height: 1;
   text-align: center;
-  font-weight: bold;
-}
+  font-weight: bold; }
 
-/* line 1349, ../../sass/_elements.sass */
 .dd-item > button:before {
   content: "+";
   display: block;
   position: absolute;
   width: 100%;
   text-align: center;
-  text-indent: 0;
-}
+  text-indent: 0; }
 
-/* line 1358, ../../sass/_elements.sass */
 .dd-item > button[data-action="collapse"]:before {
-  content: "-";
-}
+  content: "-"; }
 
-/* line 1362, ../../sass/_elements.sass */
 #nestable2 .dd-item > button {
   font-family: FontAwesome;
   height: 34px;
   width: 33px;
-  color: #c1c1c1;
-}
+  color: #c1c1c1; }
 
-/* line 1370, ../../sass/_elements.sass */
 #nestable2 .dd-item > button:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 1374, ../../sass/_elements.sass */
 #nestable2 .dd-item > button[data-action="collapse"]:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 1378, ../../sass/_elements.sass */
 .dd-placeholder,
 .dd-empty {
   margin: 5px 0;
@@ -2909,10 +2019,8 @@ div.dt-button-info {
   background: #f2fbff;
   border: 1px dashed #b6bcbf;
   box-sizing: border-box;
-  -moz-box-sizing: border-box;
-}
+  -moz-box-sizing: border-box; }
 
-/* line 1389, ../../sass/_elements.sass */
 .dd-empty {
   border: 1px dashed #bbb;
   min-height: 100px;
@@ -2921,29 +2029,21 @@ div.dt-button-info {
   background-image: -moz-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff), -moz-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff);
   background-image: linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff), linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff);
   background-size: 60px 60px;
-  background-position: 0 0, 30px 30px;
-}
+  background-position: 0 0, 30px 30px; }
 
-/* line 1400, ../../sass/_elements.sass */
 .dd-dragel {
   position: absolute;
   z-index: 9999;
-  pointer-events: none;
-}
+  pointer-events: none; }
 
-/* line 1406, ../../sass/_elements.sass */
 .dd-dragel > .dd-item .dd-handle {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 1410, ../../sass/_elements.sass */
 .dd-dragel .dd-handle {
   -webkit-box-shadow: 2px 4px 6px 0 rgba(0, 0, 0, 0.1);
-  box-shadow: 2px 4px 6px 0 rgba(0, 0, 0, 0.1);
-}
+  box-shadow: 2px 4px 6px 0 rgba(0, 0, 0, 0.1); }
 
 /* Nestable Extras */
-/* line 1416, ../../sass/_elements.sass */
 .nestable-lists {
   display: block;
   clear: both;
@@ -2951,16 +2051,12 @@ div.dt-button-info {
   width: 100%;
   border: 0;
   border-top: 2px solid #ddd;
-  border-bottom: 2px solid #ddd;
-}
+  border-bottom: 2px solid #ddd; }
 
-/* line 1426, ../../sass/_elements.sass */
 #nestable-menu {
   padding: 0;
-  margin: 10px 0 20px 0;
-}
+  margin: 10px 0 20px 0; }
 
-/* line 1431, ../../sass/_elements.sass */
 #nestable-output,
 #nestable2-output {
   width: 100%;
@@ -2969,126 +2065,86 @@ div.dt-button-info {
   font-family: open sans, lucida grande, lucida sans unicode, helvetica, arial, sans-serif;
   padding: 5px;
   box-sizing: border-box;
-  -moz-box-sizing: border-box;
-}
+  -moz-box-sizing: border-box; }
 
-/* line 1442, ../../sass/_elements.sass */
 #nestable2 .dd-handle {
   color: inherit;
   border: 1px dashed #e7eaec;
   background: #f3f3f4;
-  padding: 10px;
-}
+  padding: 10px; }
 
-/* line 1449, ../../sass/_elements.sass */
 #nestable2 span.label {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 1453, ../../sass/_elements.sass */
 #nestable-output,
 #nestable2-output {
   font-size: 12px;
   padding: 25px;
   box-sizing: border-box;
-  -moz-box-sizing: border-box;
-}
+  -moz-box-sizing: border-box; }
 
 /* CodeMirror */
-/* line 1462, ../../sass/_elements.sass */
 .CodeMirror {
   border: 1px solid #eee;
-  height: auto;
-}
+  height: auto; }
 
-/* line 1467, ../../sass/_elements.sass */
 .CodeMirror-scroll {
   overflow-y: hidden;
-  overflow-x: auto;
-}
+  overflow-x: auto; }
 
 /* Google Maps */
-/* line 1473, ../../sass/_elements.sass */
 .google-map {
-  height: 300px;
-}
+  height: 300px; }
 
 /* Validation */
-/* line 1478, ../../sass/_elements.sass */
 label.error {
   color: #cc5965;
   display: inline-block;
-  margin-left: 5px;
-}
+  margin-left: 5px; }
 
-/* line 1484, ../../sass/_elements.sass */
 .form-control.error {
-  border: 1px dotted #cc5965;
-}
+  border: 1px dotted #cc5965; }
 
 /* ngGrid */
-/* line 1489, ../../sass/_elements.sass */
 .gridStyle {
   border: 1px solid #d4d4d4;
   width: 100%;
-  height: 400px;
-}
+  height: 400px; }
 
-/* line 1495, ../../sass/_elements.sass */
 .gridStyle2 {
   border: 1px solid #d4d4d4;
   width: 500px;
-  height: 300px;
-}
+  height: 300px; }
 
-/* line 1501, ../../sass/_elements.sass */
 .ngH eaderCell {
   border-right: none;
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 1506, ../../sass/_elements.sass */
 .ngCell {
-  border-right: none;
-}
+  border-right: none; }
 
-/* line 1510, ../../sass/_elements.sass */
 .ngTopPanel {
-  background: #F5F5F6;
-}
+  background: #F5F5F6; }
 
-/* line 1514, ../../sass/_elements.sass */
 .ngRow.even {
-  background: #f9f9f9;
-}
+  background: #f9f9f9; }
 
-/* line 1518, ../../sass/_elements.sass */
 .ngRow.selected {
-  background: #EBF2F1;
-}
+  background: #EBF2F1; }
 
-/* line 1522, ../../sass/_elements.sass */
 .ngRow {
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 1526, ../../sass/_elements.sass */
 .ngCell {
-  background-color: transparent;
-}
+  background-color: transparent; }
 
-/* line 1530, ../../sass/_elements.sass */
 .ngHeaderCell {
-  border-right: none;
-}
+  border-right: none; }
 
 /* Toastr custom style */
-/* line 1536, ../../sass/_elements.sass */
 #toast-container > .toast {
-  background-image: none !important;
-}
+  background-image: none !important; }
 
-/* line 1540, ../../sass/_elements.sass */
 #toast-container > .toast:before {
   position: fixed;
   font-family: FontAwesome;
@@ -3097,40 +2153,28 @@ label.error {
   float: left;
   color: #FFF;
   padding-right: 0.5em;
-  margin: auto 0.5em auto -1.5em;
-}
+  margin: auto 0.5em auto -1.5em; }
 
-/* line 1551, ../../sass/_elements.sass */
 #toast-container > .toast-warning:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 1555, ../../sass/_elements.sass */
 #toast-container > .toast-error:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 1559, ../../sass/_elements.sass */
 #toast-container > .toast-info:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 1563, ../../sass/_elements.sass */
 #toast-container > .toast-success:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 1567, ../../sass/_elements.sass */
 #toast-container > div {
   -moz-box-shadow: 0 0 3px #999;
   -webkit-box-shadow: 0 0 3px #999;
   box-shadow: 0 0 3px #999;
   opacity: 0.9;
   -ms-filter: alpha(Opacity=90);
-  filter: alpha(opacity=90);
-}
+  filter: alpha(opacity=90); }
 
-/* line 1576, ../../sass/_elements.sass */
 #toast-container > :hover {
   -moz-box-shadow: 0 0 4px #999;
   -webkit-box-shadow: 0 0 4px #999;
@@ -3138,46 +2182,30 @@ label.error {
   opacity: 1;
   -ms-filter: alpha(Opacity=100);
   filter: alpha(opacity=100);
-  cursor: pointer;
-}
+  cursor: pointer; }
 
-/* line 1586, ../../sass/_elements.sass */
 .toast {
-  background-color: #1ab394;
-}
+  background-color: #1ab394; }
 
-/* line 1590, ../../sass/_elements.sass */
 .toast-success {
-  background-color: #1ab394;
-}
+  background-color: #1ab394; }
 
-/* line 1594, ../../sass/_elements.sass */
 .toast-error {
-  background-color: #ED5565;
-}
+  background-color: #ED5565; }
 
-/* line 1598, ../../sass/_elements.sass */
 .toast-info {
-  background-color: #23c6c8;
-}
+  background-color: #23c6c8; }
 
-/* line 1602, ../../sass/_elements.sass */
 .toast-warning {
-  background-color: #f8ac59;
-}
+  background-color: #f8ac59; }
 
-/* line 1606, ../../sass/_elements.sass */
 .toast-top-full-width {
-  margin-top: 20px;
-}
+  margin-top: 20px; }
 
-/* line 1610, ../../sass/_elements.sass */
 .toast-bottom-full-width {
-  margin-bottom: 20px;
-}
+  margin-bottom: 20px; }
 
 /* Notifie */
-/* line 1615, ../../sass/_elements.sass */
 .cg-notify-message.inspinia-notify {
   background: #fff;
   padding: 0;
@@ -3186,237 +2214,162 @@ label.error {
   -moz-box-shadow: 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.2);
   border: none;
   margin-top: 30px;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 1626, ../../sass/_elements.sass */
 .inspinia-notify.alert-warning {
-  border-left: 6px solid #f8ac59;
-}
+  border-left: 6px solid #f8ac59; }
 
-/* line 1630, ../../sass/_elements.sass */
 .inspinia-notify.alert-success {
-  border-left: 6px solid #1c84c6;
-}
+  border-left: 6px solid #1c84c6; }
 
-/* line 1634, ../../sass/_elements.sass */
 .inspinia-notify.alert-danger {
-  border-left: 6px solid #ED5565;
-}
+  border-left: 6px solid #ED5565; }
 
-/* line 1638, ../../sass/_elements.sass */
 .inspinia-notify.alert-info {
-  border-left: 6px solid #1ab394;
-}
+  border-left: 6px solid #1ab394; }
 
 /* Image cropper style */
-/* line 1643, ../../sass/_elements.sass */
 .img-container, .img-preview {
   overflow: hidden;
   text-align: center;
-  width: 100%;
-}
+  width: 100%; }
 
-/* line 1649, ../../sass/_elements.sass */
 .img-preview-sm {
   height: 130px;
-  width: 200px;
-}
+  width: 200px; }
 
 /* Forum styles  */
-/* line 1655, ../../sass/_elements.sass */
 .forum-post-container .media {
   margin: 10px 10px 10px 10px;
   padding: 20px 10px 20px 10px;
-  border-bottom: 1px solid #f1f1f1;
-}
+  border-bottom: 1px solid #f1f1f1; }
 
-/* line 1661, ../../sass/_elements.sass */
 .forum-avatar {
   float: left;
   margin-right: 20px;
   text-align: center;
-  width: 110px;
-}
+  width: 110px; }
 
-/* line 1668, ../../sass/_elements.sass */
 .forum-avatar .img-circle {
   height: 48px;
-  width: 48px;
-}
+  width: 48px; }
 
-/* line 1673, ../../sass/_elements.sass */
 .author-info {
   color: #676a6c;
   font-size: 11px;
   margin-top: 5px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 1680, ../../sass/_elements.sass */
 .forum-post-info {
   padding: 9px 12px 6px 12px;
   background: #f9f9f9;
-  border: 1px solid #f1f1f1;
-}
+  border: 1px solid #f1f1f1; }
 
-/* line 1686, ../../sass/_elements.sass */
 .media-body > .media {
   background: #f9f9f9;
   border-radius: 3px;
-  border: 1px solid #f1f1f1;
-}
+  border: 1px solid #f1f1f1; }
 
-/* line 1692, ../../sass/_elements.sass */
 .forum-post-container .media-body .photos {
-  margin: 10px 0;
-}
+  margin: 10px 0; }
 
-/* line 1696, ../../sass/_elements.sass */
 .forum-photo {
   max-width: 140px;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 1702, ../../sass/_elements.sass */
 .media-body > .media .forum-avatar {
   width: 70px;
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 1707, ../../sass/_elements.sass */
 .media-body > .media .forum-avatar .img-circle {
   height: 38px;
-  width: 38px;
-}
+  width: 38px; }
 
-/* line 1712, ../../sass/_elements.sass */
 .mid-icon {
-  font-size: 66px;
-}
+  font-size: 66px; }
 
-/* line 1716, ../../sass/_elements.sass */
 .forum-item {
   margin: 10px 0;
   padding: 10px 0 20px;
-  border-bottom: 1px solid #f1f1f1;
-}
+  border-bottom: 1px solid #f1f1f1; }
 
-/* line 1722, ../../sass/_elements.sass */
 .views-number {
   font-size: 24px;
   line-height: 18px;
-  font-weight: 400;
-}
+  font-weight: 400; }
 
-/* line 1728, ../../sass/_elements.sass */
 .forum-container, .forum-post-container {
-  padding: 30px !important;
-}
+  padding: 30px !important; }
 
-/* line 1732, ../../sass/_elements.sass */
 .forum-item small {
-  color: #999;
-}
+  color: #999; }
 
-/* line 1736, ../../sass/_elements.sass */
 .forum-item .forum-sub-title {
   color: #999;
-  margin-left: 50px;
-}
+  margin-left: 50px; }
 
-/* line 1741, ../../sass/_elements.sass */
 .forum-title {
-  margin: 15px 0 15px 0;
-}
+  margin: 15px 0 15px 0; }
 
-/* line 1745, ../../sass/_elements.sass */
 .forum-info {
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 1749, ../../sass/_elements.sass */
 .forum-desc {
-  color: #999;
-}
+  color: #999; }
 
-/* line 1753, ../../sass/_elements.sass */
 .forum-icon {
   float: left;
   width: 30px;
   margin-right: 20px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 1760, ../../sass/_elements.sass */
 a.forum-item-title {
   color: inherit;
   display: block;
   font-size: 18px;
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 1767, ../../sass/_elements.sass */
 a.forum-item-title:hover {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 1771, ../../sass/_elements.sass */
 .forum-icon .fa {
   font-size: 30px;
   margin-top: 8px;
-  color: #9b9b9b;
-}
+  color: #9b9b9b; }
 
-/* line 1778, ../../sass/_elements.sass */
 .forum-item.active .fa {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 1782, ../../sass/_elements.sass */
 .forum-item.active a.forum-item-title {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
 @media (max-width: 992px) {
-  /* line 1788, ../../sass/_elements.sass */
   .forum-info {
     margin: 15px 0 10px 0;
     /* Comment this is you want to show forum info in small devices */
-    display: none;
-  }
+    display: none; }
 
-  /* line 1795, ../../sass/_elements.sass */
   .forum-desc {
-    float: none !important;
-  }
-}
+    float: none !important; } }
 /* New Timeline style */
-/* line 1803, ../../sass/_elements.sass */
 .vertical-container {
   /* this class is used to give a max-width to the element it is applied to, and center it horizontally when it reaches that max-width */
   width: 90%;
   max-width: 1170px;
-  margin: 0 auto;
-}
+  margin: 0 auto; }
 
-/* line 1810, ../../sass/_elements.sass */
 .vertical-container::after {
   /* clearfix */
   content: "";
   display: table;
-  clear: both;
-}
+  clear: both; }
 
-/* line 1817, ../../sass/_elements.sass */
 #vertical-timeline {
   position: relative;
   padding: 0;
   margin-top: 2em;
-  margin-bottom: 2em;
-}
+  margin-bottom: 2em; }
 
-/* line 1824, ../../sass/_elements.sass */
 #vertical-timeline::before {
   content: "";
   position: absolute;
@@ -3424,100 +2377,63 @@ a.forum-item-title:hover {
   left: 18px;
   height: 100%;
   width: 4px;
-  background: #f1f1f1;
-}
+  background: #f1f1f1; }
 
-/* line 1834, ../../sass/_elements.sass */
 .vertical-timeline-content .btn {
-  float: right;
-}
+  float: right; }
 
-/* line 1838, ../../sass/_elements.sass */
 #vertical-timeline.light-timeline:before {
-  background: #e7eaec;
-}
+  background: #e7eaec; }
 
-/* line 1842, ../../sass/_elements.sass */
 .dark-timeline .vertical-timeline-content:before {
-  border-color: transparent #f5f5f5 transparent transparent;
-}
+  border-color: transparent #f5f5f5 transparent transparent; }
 
-/* line 1846, ../../sass/_elements.sass */
 .dark-timeline.center-orientation .vertical-timeline-content:before {
-  border-color: transparent transparent transparent #f5f5f5;
-}
+  border-color: transparent transparent transparent #f5f5f5; }
 
-/* line 1850, ../../sass/_elements.sass */
 .dark-timeline .vertical-timeline-block:nth-child(2n) .vertical-timeline-content:before,
 .dark-timeline.center-orientation .vertical-timeline-block:nth-child(2n) .vertical-timeline-content:before {
-  border-color: transparent #f5f5f5 transparent transparent;
-}
+  border-color: transparent #f5f5f5 transparent transparent; }
 
-/* line 1855, ../../sass/_elements.sass */
 .dark-timeline .vertical-timeline-content,
 .dark-timeline.center-orientation .vertical-timeline-content {
-  background: #f5f5f5;
-}
+  background: #f5f5f5; }
 
 @media only screen and (min-width: 1170px) {
-  /* line 1861, ../../sass/_elements.sass */
   #vertical-timeline.center-orientation {
     margin-top: 3em;
-    margin-bottom: 3em;
-  }
+    margin-bottom: 3em; }
 
-  /* line 1866, ../../sass/_elements.sass */
   #vertical-timeline.center-orientation:before {
     left: 50%;
-    margin-left: -2px;
-  }
-}
+    margin-left: -2px; } }
 @media only screen and (max-width: 1170px) {
-  /* line 1873, ../../sass/_elements.sass */
   .center-orientation.dark-timeline .vertical-timeline-content:before {
-    border-color: transparent #f5f5f5 transparent transparent;
-  }
-}
-/* line 1878, ../../sass/_elements.sass */
+    border-color: transparent #f5f5f5 transparent transparent; } }
 .vertical-timeline-block {
   position: relative;
-  margin: 2em 0;
-}
+  margin: 2em 0; }
 
-/* line 1883, ../../sass/_elements.sass */
 .vertical-timeline-block:after {
   content: "";
   display: table;
-  clear: both;
-}
+  clear: both; }
 
-/* line 1889, ../../sass/_elements.sass */
 .vertical-timeline-block:first-child {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 1893, ../../sass/_elements.sass */
 .vertical-timeline-block:last-child {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
 @media only screen and (min-width: 1170px) {
-  /* line 1898, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-block {
-    margin: 4em 0;
-  }
+    margin: 4em 0; }
 
-  /* line 1902, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-block:first-child {
-    margin-top: 0;
-  }
+    margin-top: 0; }
 
-  /* line 1906, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-block:last-child {
-    margin-bottom: 0;
-  }
-}
-/* line 1911, ../../sass/_elements.sass */
+    margin-bottom: 0; } }
 .vertical-timeline-icon {
   position: absolute;
   top: 0;
@@ -3527,10 +2443,8 @@ a.forum-item-title:hover {
   border-radius: 50%;
   font-size: 16px;
   border: 3px solid #f1f1f1;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 1923, ../../sass/_elements.sass */
 .vertical-timeline-icon i {
   display: block;
   width: 24px;
@@ -3539,11 +2453,9 @@ a.forum-item-title:hover {
   left: 50%;
   top: 50%;
   margin-left: -12px;
-  margin-top: -9px;
-}
+  margin-top: -9px; }
 
 @media only screen and (min-width: 1170px) {
-  /* line 1935, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-icon {
     width: 50px;
     height: 50px;
@@ -3551,61 +2463,42 @@ a.forum-item-title:hover {
     margin-left: -25px;
     -webkit-transform: translateZ(0);
     -webkit-backface-visibility: hidden;
-    font-size: 19px;
-  }
+    font-size: 19px; }
 
-  /* line 1945, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-icon i {
     margin-left: -12px;
-    margin-top: -10px;
-  }
+    margin-top: -10px; }
 
-  /* line 1950, ../../sass/_elements.sass */
   .center-orientation .cssanimations .vertical-timeline-icon.is-hidden {
-    visibility: hidden;
-  }
-}
-/* line 1955, ../../sass/_elements.sass */
+    visibility: hidden; } }
 .vertical-timeline-content {
   position: relative;
   margin-left: 60px;
   background: white;
   border-radius: 0.25em;
-  padding: 1em;
-}
+  padding: 1em; }
 
-/* line 1963, ../../sass/_elements.sass */
 .vertical-timeline-content:after {
   content: "";
   display: table;
-  clear: both;
-}
+  clear: both; }
 
-/* line 1969, ../../sass/_elements.sass */
 .vertical-timeline-content h2 {
   font-weight: 400;
-  margin-top: 4px;
-}
+  margin-top: 4px; }
 
-/* line 1974, ../../sass/_elements.sass */
 .vertical-timeline-content p {
   margin: 1em 0;
-  line-height: 1.6;
-}
+  line-height: 1.6; }
 
-/* line 1979, ../../sass/_elements.sass */
 .vertical-timeline-content .vertical-date {
   float: left;
-  font-weight: 500;
-}
+  font-weight: 500; }
 
-/* line 1984, ../../sass/_elements.sass */
 .vertical-date small {
   color: #1ab394;
-  font-weight: 400;
-}
+  font-weight: 400; }
 
-/* line 1989, ../../sass/_elements.sass */
 .vertical-timeline-content::before {
   content: "";
   position: absolute;
@@ -3614,256 +2507,167 @@ a.forum-item-title:hover {
   height: 0;
   width: 0;
   border: 7px solid transparent;
-  border-right: 7px solid white;
-}
+  border-right: 7px solid white; }
 
 @media only screen and (min-width: 768px) {
-  /* line 2001, ../../sass/_elements.sass */
   .vertical-timeline-content h2 {
-    font-size: 18px;
-  }
+    font-size: 18px; }
 
-  /* line 2005, ../../sass/_elements.sass */
   .vertical-timeline-content p {
-    font-size: 13px;
-  }
-}
+    font-size: 13px; } }
 @media only screen and (min-width: 1170px) {
-  /* line 2012, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-content {
     margin-left: 0;
     padding: 1.6em;
-    width: 45%;
-  }
+    width: 45%; }
 
-  /* line 2018, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-content::before {
     top: 24px;
     left: 100%;
     border-color: transparent;
-    border-left-color: white;
-  }
+    border-left-color: white; }
 
-  /* line 2025, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-content .btn {
-    float: left;
-  }
+    float: left; }
 
-  /* line 2029, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-content .vertical-date {
     position: absolute;
     width: 100%;
     left: 122%;
     top: 2px;
-    font-size: 14px;
-  }
+    font-size: 14px; }
 
-  /* line 2037, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-block:nth-child(even) .vertical-timeline-content {
-    float: right;
-  }
+    float: right; }
 
-  /* line 2041, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-block:nth-child(even) .vertical-timeline-content::before {
     top: 24px;
     left: auto;
     right: 100%;
     border-color: transparent;
-    border-right-color: white;
-  }
+    border-right-color: white; }
 
-  /* line 2049, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-block:nth-child(even) .vertical-timeline-content .btn {
-    float: right;
-  }
+    float: right; }
 
-  /* line 2053, ../../sass/_elements.sass */
   .center-orientation .vertical-timeline-block:nth-child(even) .vertical-timeline-content .vertical-date {
     left: auto;
     right: 122%;
-    text-align: right;
-  }
+    text-align: right; }
 
-  /* line 2059, ../../sass/_elements.sass */
   .center-orientation .cssanimations .vertical-timeline-content.is-hidden {
-    visibility: hidden;
-  }
-}
+    visibility: hidden; } }
 /* Tabs */
-/* line 2068, ../../sass/_elements.sass */
 .tabs-container .panel-body {
   background: #fff;
   border: 1px solid #e7eaec;
   border-radius: 2px;
   padding: 20px;
-  position: relative;
-}
-/* line 2076, ../../sass/_elements.sass */
+  position: relative; }
 .tabs-container .nav-tabs > li.active > a,
 .tabs-container .nav-tabs > li.active > a:hover,
 .tabs-container .nav-tabs > li.active > a:focus {
   border: 1px solid #e7eaec;
   border-bottom-color: transparent;
-  background-color: #fff;
-}
-/* line 2084, ../../sass/_elements.sass */
+  background-color: #fff; }
 .tabs-container .nav-tabs > li {
   float: left;
-  margin-bottom: -1px;
-}
-/* line 2089, ../../sass/_elements.sass */
+  margin-bottom: -1px; }
 .tabs-container .tab-pane .panel-body {
-  border-top: none;
-}
-/* line 2093, ../../sass/_elements.sass */
+  border-top: none; }
 .tabs-container .nav-tabs > li.active > a, .tabs-container .nav-tabs > li.active > a:hover, .tabs-container .nav-tabs > li.active > a:focus {
   border: 1px solid #e7eaec;
-  border-bottom-color: transparent;
-}
-/* line 2098, ../../sass/_elements.sass */
+  border-bottom-color: transparent; }
 .tabs-container .nav-tabs {
-  border-bottom: 1px solid #e7eaec;
-}
-/* line 2102, ../../sass/_elements.sass */
+  border-bottom: 1px solid #e7eaec; }
 .tabs-container .tab-pane .panel-body {
-  border-top: none;
-}
-/* line 2106, ../../sass/_elements.sass */
+  border-top: none; }
 .tabs-container .tabs-left .tab-pane .panel-body, .tabs-container .tabs-right .tab-pane .panel-body {
-  border-top: 1px solid #e7eaec;
-}
-/* line 2110, ../../sass/_elements.sass */
+  border-top: 1px solid #e7eaec; }
 .tabs-container .nav-tabs > li a:hover {
   background: transparent;
-  border-color: transparent;
-}
-/* line 2115, ../../sass/_elements.sass */
+  border-color: transparent; }
 .tabs-container .tabs-below > .nav-tabs,
 .tabs-container .tabs-right > .nav-tabs,
 .tabs-container .tabs-left > .nav-tabs {
-  border-bottom: 0;
-}
-/* line 2121, ../../sass/_elements.sass */
+  border-bottom: 0; }
 .tabs-container .tabs-left .panel-body {
-  position: static;
-}
-/* line 2125, ../../sass/_elements.sass */
+  position: static; }
 .tabs-container .tabs-left > .nav-tabs, .tabs-container .tabs-right > .nav-tabs {
-  width: 20%;
-}
-/* line 2129, ../../sass/_elements.sass */
+  width: 20%; }
 .tabs-container .tabs-left .panel-body {
   width: 80%;
-  margin-left: 20%;
-}
-/* line 2134, ../../sass/_elements.sass */
+  margin-left: 20%; }
 .tabs-container .tabs-right .panel-body {
   width: 80%;
-  margin-right: 20%;
-}
-/* line 2139, ../../sass/_elements.sass */
+  margin-right: 20%; }
 .tabs-container .tab-content > .tab-pane,
 .tabs-container .pill-content > .pill-pane {
-  display: none;
-}
-/* line 2144, ../../sass/_elements.sass */
+  display: none; }
 .tabs-container .tab-content > .active,
 .tabs-container .pill-content > .active {
-  display: block;
-}
-/* line 2149, ../../sass/_elements.sass */
+  display: block; }
 .tabs-container .tabs-below > .nav-tabs {
-  border-top: 1px solid #e7eaec;
-}
-/* line 2153, ../../sass/_elements.sass */
+  border-top: 1px solid #e7eaec; }
 .tabs-container .tabs-below > .nav-tabs > li {
   margin-top: -1px;
-  margin-bottom: 0;
-}
-/* line 2158, ../../sass/_elements.sass */
+  margin-bottom: 0; }
 .tabs-container .tabs-below > .nav-tabs > li > a {
   -webkit-border-radius: 0 0 4px 4px;
   -moz-border-radius: 0 0 4px 4px;
-  border-radius: 0 0 4px 4px;
-}
-/* line 2164, ../../sass/_elements.sass */
+  border-radius: 0 0 4px 4px; }
 .tabs-container .tabs-below > .nav-tabs > li > a:hover,
 .tabs-container .tabs-below > .nav-tabs > li > a:focus {
   border-top-color: #e7eaec;
-  border-bottom-color: transparent;
-}
-/* line 2170, ../../sass/_elements.sass */
+  border-bottom-color: transparent; }
 .tabs-container .tabs-left > .nav-tabs > li,
 .tabs-container .tabs-right > .nav-tabs > li {
-  float: none;
-}
-/* line 2175, ../../sass/_elements.sass */
+  float: none; }
 .tabs-container .tabs-left > .nav-tabs > li > a,
 .tabs-container .tabs-right > .nav-tabs > li > a {
   min-width: 74px;
   margin-right: 0;
-  margin-bottom: 3px;
-}
-/* line 2182, ../../sass/_elements.sass */
+  margin-bottom: 3px; }
 .tabs-container .tabs-left > .nav-tabs {
   float: left;
-  margin-right: 19px;
-}
-/* line 2187, ../../sass/_elements.sass */
+  margin-right: 19px; }
 .tabs-container .tabs-left > .nav-tabs > li > a {
   margin-right: -1px;
   -webkit-border-radius: 4px 0 0 4px;
   -moz-border-radius: 4px 0 0 4px;
-  border-radius: 4px 0 0 4px;
-}
-/* line 2194, ../../sass/_elements.sass */
+  border-radius: 4px 0 0 4px; }
 .tabs-container .tabs-left > .nav-tabs .active > a,
 .tabs-container .tabs-left > .nav-tabs .active > a:hover,
 .tabs-container .tabs-left > .nav-tabs .active > a:focus {
-  border-color: #e7eaec transparent #e7eaec #e7eaec;
-}
-/* line 2200, ../../sass/_elements.sass */
+  border-color: #e7eaec transparent #e7eaec #e7eaec; }
 .tabs-container .tabs-right > .nav-tabs {
   float: right;
-  margin-left: 19px;
-}
-/* line 2205, ../../sass/_elements.sass */
+  margin-left: 19px; }
 .tabs-container .tabs-right > .nav-tabs > li > a {
   margin-left: -1px;
   -webkit-border-radius: 0 4px 4px 0;
   -moz-border-radius: 0 4px 4px 0;
-  border-radius: 0 4px 4px 0;
-}
-/* line 2212, ../../sass/_elements.sass */
+  border-radius: 0 4px 4px 0; }
 .tabs-container .tabs-right > .nav-tabs .active > a,
 .tabs-container .tabs-right > .nav-tabs .active > a:hover,
 .tabs-container .tabs-right > .nav-tabs .active > a:focus {
   border-color: #e7eaec #e7eaec #e7eaec transparent;
-  z-index: 1;
-}
+  z-index: 1; }
 
 @media (max-width: 767px) {
-  /* line 2222, ../../sass/_elements.sass */
   .tabs-container .nav-tabs > li {
-    float: none !important;
-  }
+    float: none !important; }
 
-  /* line 2226, ../../sass/_elements.sass */
   .tabs-container .nav-tabs > li.active > a {
     border-bottom: 1px solid #e7eaec !important;
-    margin: 0;
-  }
-}
+    margin: 0; } }
 /* jsvectormap */
-/* line 2233, ../../sass/_elements.sass */
 .jvectormap-container {
   width: 100%;
   height: 100%;
   position: relative;
-  overflow: hidden;
-}
+  overflow: hidden; }
 
-/* line 2240, ../../sass/_elements.sass */
 .jvectormap-tip {
   position: absolute;
   display: none;
@@ -3873,10 +2677,8 @@ a.forum-item-title:hover {
   color: white;
   font-family: sans-serif, Verdana;
   font-size: smaller;
-  padding: 5px;
-}
+  padding: 5px; }
 
-/* line 2252, ../../sass/_elements.sass */
 .jvectormap-zoomin, .jvectormap-zoomout, .jvectormap-goback {
   position: absolute;
   left: 10px;
@@ -3887,399 +2689,265 @@ a.forum-item-title:hover {
   cursor: pointer;
   line-height: 10px;
   text-align: center;
-  box-sizing: content-box;
-}
+  box-sizing: content-box; }
 
-/* line 2265, ../../sass/_elements.sass */
 .jvectormap-zoomin, .jvectormap-zoomout {
   width: 10px;
-  height: 10px;
-}
+  height: 10px; }
 
-/* line 2270, ../../sass/_elements.sass */
 .jvectormap-zoomin {
-  top: 10px;
-}
+  top: 10px; }
 
-/* line 2274, ../../sass/_elements.sass */
 .jvectormap-zoomout {
-  top: 30px;
-}
+  top: 30px; }
 
-/* line 2278, ../../sass/_elements.sass */
 .jvectormap-goback {
   bottom: 10px;
   z-index: 1000;
-  padding: 6px;
-}
+  padding: 6px; }
 
-/* line 2284, ../../sass/_elements.sass */
 .jvectormap-spinner {
   position: absolute;
   left: 0;
   top: 0;
   right: 0;
   bottom: 0;
-  background: center no-repeat url(data:image/gifbase64,R0lGODlhIAAgAPMAAP///wAAAMbGxoSEhLa2tpqamjY2NlZWVtjY2OTk5Ly8vB4eHgQEBAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAIAAgAAAE5xDISWlhperN52JLhSSdRgwVo1ICQZRUsiwHpTJT4iowNS8vyW2icCF6k8HMMBkCEDskxTBDAZwuAkkqIfxIQyhBQBFvAQSDITM5VDW6XNE4KagNh6Bgwe60smQUB3d4Rz1ZBApnFASDd0hihh12BkE9kjAJVlycXIg7CQIFA6SlnJ87paqbSKiKoqusnbMdmDC2tXQlkUhziYtyWTxIfy6BE8WJt5YJvpJivxNaGmLHT0VnOgSYf0dZXS7APdpB309RnHOG5gDqXGLDaC457D1zZ/V/nmOM82XiHRLYKhKP1oZmADdEAAAh+QQJCgAAACwAAAAAIAAgAAAE6hDISWlZpOrNp1lGNRSdRpDUolIGw5RUYhhHukqFu8DsrEyqnWThGvAmhVlteBvojpTDDBUEIFwMFBRAmBkSgOrBFZogCASwBDEY/CZSg7GSE0gSCjQBMVG023xWBhklAnoEdhQEfyNqMIcKjhRsjEdnezB+A4k8gTwJhFuiW4dokXiloUepBAp5qaKpp6+Ho7aWW54wl7obvEe0kRuoplCGepwSx2jJvqHEmGt6whJpGpfJCHmOoNHKaHx61WiSR92E4lbFoq+B6QDtuetcaBPnW6+O7wDHpIiK9SaVK5GgV543tzjgGcghAgAh+QQJCgAAACwAAAAAIAAgAAAE7hDISSkxpOrN5zFHNWRdhSiVoVLHspRUMoyUakyEe8PTPCATW9A14E0UvuAKMNAZKYUZCiBMuBakSQKG8G2FzUWox2AUtAQFcBKlVQoLgQReZhQlCIJesQXI5B0CBnUMOxMCenoCfTCEWBsJColTMANldx15BGs8B5wlCZ9Po6OJkwmRpnqkqnuSrayqfKmqpLajoiW5HJq7FL1Gr2mMMcKUMIiJgIemy7xZtJsTmsM4xHiKv5KMCXqfyUCJEonXPN2rAOIAmsfB3uPoAK++G+w48edZPK+M6hLJpQg484enXIdQFSS1u6UhksENEQAAIfkECQoAAAAsAAAAACAAIAAABOcQyEmpGKLqzWcZRVUQnZYg1aBSh2GUVEIQ2aQOE+G+cD4ntpWkZQj1JIiZIogDFFyHI0UxQwFugMSOFIPJftfVAEoZLBbcLEFhlQiqGp1Vd140AUklUN3eCA51C1EWMzMCezCBBmkxVIVHBWd3HHl9JQOIJSdSnJ0TDKChCwUJjoWMPaGqDKannasMo6WnM562R5YluZRwur0wpgqZE7NKUm+FNRPIhjBJxKZteWuIBMN4zRMIVIhffcgojwCF117i4nlLnY5ztRLsnOk+aV+oJY7V7m76PdkS4trKcdg0Zc0tTcKkRAAAIfkECQoAAAAsAAAAACAAIAAABO4QyEkpKqjqzScpRaVkXZWQEximw1BSCUEIlDohrft6cpKCk5xid5MNJTaAIkekKGQkWyKHkvhKsR7ARmitkAYDYRIbUQRQjWBwJRzChi9CRlBcY1UN4g0/VNB0AlcvcAYHRyZPdEQFYV8ccwR5HWxEJ02YmRMLnJ1xCYp0Y5idpQuhopmmC2KgojKasUQDk5BNAwwMOh2RtRq5uQuPZKGIJQIGwAwGf6I0JXMpC8C7kXWDBINFMxS4DKMAWVWAGYsAdNqW5uaRxkSKJOZKaU3tPOBZ4DuK2LATgJhkPJMgTwKCdFjyPHEnKxFCDhEAACH5BAkKAAAALAAAAAAgACAAAATzEMhJaVKp6s2nIkolIJ2WkBShpkVRWqqQrhLSEu9MZJKK9y1ZrqYK9WiClmvoUaF8gIQSNeF1Er4MNFn4SRSDARWroAIETg1iVwuHjYB1kYc1mwruwXKC9gmsJXliGxc+XiUCby9ydh1sOSdMkpMTBpaXBzsfhoc5l58Gm5yToAaZhaOUqjkDgCWNHAULCwOLaTmzswadEqggQwgHuQsHIoZCHQMMQgQGubVEcxOPFAcMDAYUA85eWARmfSRQCdcMe0zeP1AAygwLlJtPNAAL19DARdPzBOWSm1brJBi45soRAWQAAkrQIykShQ9wVhHCwCQCACH5BAkKAAAALAAAAAAgACAAAATrEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq+E71SRQeyqUToLA7VxF0JDyIQh/MVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiRMDjI0Fd30/iI2UA5GSS5UDj2l6NoqgOgN4gksEBgYFf0FDqKgHnyZ9OX8HrgYHdHpcHQULXAS2qKpENRg7eAMLC7kTBaixUYFkKAzWAAnLC7FLVxLWDBLKCwaKTULgEwbLA4hJtOkSBNqITT3xEgfLpBtzE/jiuL04RGEBgwWhShRgQExHBAAh+QQJCgAAACwAAAAAIAAgAAAE7xDISWlSqerNpyJKhWRdlSAVoVLCWk6JKlAqAavhO9UkUHsqlE6CwO1cRdCQ8iEIfzFVTzLdRAmZX3I2SfZiCqGk5dTESJeaOAlClzsJsqwiJwiqnFrb2nS9kmIcgEsjQydLiIlHehhpejaIjzh9eomSjZR+ipslWIRLAgMDOR2DOqKogTB9pCUJBagDBXR6XB0EBkIIsaRsGGMMAxoDBgYHTKJiUYEGDAzHC9EACcUGkIgFzgwZ0QsSBcXHiQvOwgDdEwfFs0sDzt4S6BK4xYjkDOzn0unFeBzOBijIm1Dgmg5YFQwsCMjp1oJ8LyIAACH5BAkKAAAALAAAAAAgACAAAATwEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq+E71SRQeyqUToLA7VxF0JDyIQh/MVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiUd6GGl6NoiPOH16iZKNlH6KmyWFOggHhEEvAwwMA0N9GBsEC6amhnVcEwavDAazGwIDaH1ipaYLBUTCGgQDA8NdHz0FpqgTBwsLqAbWAAnIA4FWKdMLGdYGEgraigbT0OITBcg5QwPT4xLrROZL6AuQAPUS7bxLpoWidY0JtxLHKhwwMJBTHgPKdEQAACH5BAkKAAAALAAAAAAgACAAAATrEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq+E71SRQeyqUToLA7VxF0JDyIQh/MVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiUd6GAULDJCRiXo1CpGXDJOUjY+Yip9DhToJA4RBLwMLCwVDfRgbBAaqqoZ1XBMHswsHtxtFaH1iqaoGNgAIxRpbFAgfPQSqpbgGBqUD1wBXeCYp1AYZ19JJOYgH1KwA4UBvQwXUBxPqVD9L3sbp2BNk2xvvFPJd+MFCN6HAAIKgNggY0KtEBAAh+QQJCgAAACwAAAAAIAAgAAAE6BDISWlSqerNpyJKhWRdlSAVoVLCWk6JKlAqAavhO9UkUHsqlE6CwO1cRdCQ8iEIfzFVTzLdRAmZX3I2SfYIDMaAFdTESJeaEDAIMxYFqrOUaNW4E4ObYcCXaiBVEgULe0NJaxxtYksjh2NLkZISgDgJhHthkpU4mW6blRiYmZOlh4JWkDqILwUGBnE6TYEbCgevr0N1gH4At7gHiRpFaLNrrq8HNgAJA70AWxQIH1+vsYMDAzZQPC9VCNkDWUhGkuE5PxJNwiUK4UfLzOlD4WvzAHaoG9nxPi5d+jYUqfAhhykOFwJWiAAAIfkECQoAAAAsAAAAACAAIAAABPAQyElpUqnqzaciSoVkXVUMFaFSwlpOCcMYlErAavhOMnNLNo8KsZsMZItJEIDIFSkLGQoQTNhIsFehRww2CQLKF0tYGKYSg+ygsZIuNqJksKgbfgIGepNo2cIUB3V1B3IvNiBYNQaDSTtfhhx0CwVPI0UJe0+bm4g5VgcGoqOcnjmjqDSdnhgEoamcsZuXO1aWQy8KAwOAuTYYGwi7w5h+Kr0SJ8MFihpNbx+4Erq7BYBuzsdiH1jCAzoSfl0rVirNbRXlBBlLX+BP0XJLAPGzTkAuAOqb0WT5AH7OcdCm5B8TgRwSRKIHQtaLCwg1RAAAOwAAAAAAAAAAAA==);
-}
+  background: center no-repeat url(data:image/gifbase64,R0lGODlhIAAgAPMAAP///wAAAMbGxoSEhLa2tpqamjY2NlZWVtjY2OTk5Ly8vB4eHgQEBAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAIAAgAAAE5xDISWlhperN52JLhSSdRgwVo1ICQZRUsiwHpTJT4iowNS8vyW2icCF6k8HMMBkCEDskxTBDAZwuAkkqIfxIQyhBQBFvAQSDITM5VDW6XNE4KagNh6Bgwe60smQUB3d4Rz1ZBApnFASDd0hihh12BkE9kjAJVlycXIg7CQIFA6SlnJ87paqbSKiKoqusnbMdmDC2tXQlkUhziYtyWTxIfy6BE8WJt5YJvpJivxNaGmLHT0VnOgSYf0dZXS7APdpB309RnHOG5gDqXGLDaC457D1zZ/V/nmOM82XiHRLYKhKP1oZmADdEAAAh+QQJCgAAACwAAAAAIAAgAAAE6hDISWlZpOrNp1lGNRSdRpDUolIGw5RUYhhHukqFu8DsrEyqnWThGvAmhVlteBvojpTDDBUEIFwMFBRAmBkSgOrBFZogCASwBDEY/CZSg7GSE0gSCjQBMVG023xWBhklAnoEdhQEfyNqMIcKjhRsjEdnezB+A4k8gTwJhFuiW4dokXiloUepBAp5qaKpp6+Ho7aWW54wl7obvEe0kRuoplCGepwSx2jJvqHEmGt6whJpGpfJCHmOoNHKaHx61WiSR92E4lbFoq+B6QDtuetcaBPnW6+O7wDHpIiK9SaVK5GgV543tzjgGcghAgAh+QQJCgAAACwAAAAAIAAgAAAE7hDISSkxpOrN5zFHNWRdhSiVoVLHspRUMoyUakyEe8PTPCATW9A14E0UvuAKMNAZKYUZCiBMuBakSQKG8G2FzUWox2AUtAQFcBKlVQoLgQReZhQlCIJesQXI5B0CBnUMOxMCenoCfTCEWBsJColTMANldx15BGs8B5wlCZ9Po6OJkwmRpnqkqnuSrayqfKmqpLajoiW5HJq7FL1Gr2mMMcKUMIiJgIemy7xZtJsTmsM4xHiKv5KMCXqfyUCJEonXPN2rAOIAmsfB3uPoAK++G+w48edZPK+M6hLJpQg484enXIdQFSS1u6UhksENEQAAIfkECQoAAAAsAAAAACAAIAAABOcQyEmpGKLqzWcZRVUQnZYg1aBSh2GUVEIQ2aQOE+G+cD4ntpWkZQj1JIiZIogDFFyHI0UxQwFugMSOFIPJftfVAEoZLBbcLEFhlQiqGp1Vd140AUklUN3eCA51C1EWMzMCezCBBmkxVIVHBWd3HHl9JQOIJSdSnJ0TDKChCwUJjoWMPaGqDKannasMo6WnM562R5YluZRwur0wpgqZE7NKUm+FNRPIhjBJxKZteWuIBMN4zRMIVIhffcgojwCF117i4nlLnY5ztRLsnOk+aV+oJY7V7m76PdkS4trKcdg0Zc0tTcKkRAAAIfkECQoAAAAsAAAAACAAIAAABO4QyEkpKqjqzScpRaVkXZWQEximw1BSCUEIlDohrft6cpKCk5xid5MNJTaAIkekKGQkWyKHkvhKsR7ARmitkAYDYRIbUQRQjWBwJRzChi9CRlBcY1UN4g0/VNB0AlcvcAYHRyZPdEQFYV8ccwR5HWxEJ02YmRMLnJ1xCYp0Y5idpQuhopmmC2KgojKasUQDk5BNAwwMOh2RtRq5uQuPZKGIJQIGwAwGf6I0JXMpC8C7kXWDBINFMxS4DKMAWVWAGYsAdNqW5uaRxkSKJOZKaU3tPOBZ4DuK2LATgJhkPJMgTwKCdFjyPHEnKxFCDhEAACH5BAkKAAAALAAAAAAgACAAAATzEMhJaVKp6s2nIkolIJ2WkBShpkVRWqqQrhLSEu9MZJKK9y1ZrqYK9WiClmvoUaF8gIQSNeF1Er4MNFn4SRSDARWroAIETg1iVwuHjYB1kYc1mwruwXKC9gmsJXliGxc+XiUCby9ydh1sOSdMkpMTBpaXBzsfhoc5l58Gm5yToAaZhaOUqjkDgCWNHAULCwOLaTmzswadEqggQwgHuQsHIoZCHQMMQgQGubVEcxOPFAcMDAYUA85eWARmfSRQCdcMe0zeP1AAygwLlJtPNAAL19DARdPzBOWSm1brJBi45soRAWQAAkrQIykShQ9wVhHCwCQCACH5BAkKAAAALAAAAAAgACAAAATrEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq+E71SRQeyqUToLA7VxF0JDyIQh/MVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiRMDjI0Fd30/iI2UA5GSS5UDj2l6NoqgOgN4gksEBgYFf0FDqKgHnyZ9OX8HrgYHdHpcHQULXAS2qKpENRg7eAMLC7kTBaixUYFkKAzWAAnLC7FLVxLWDBLKCwaKTULgEwbLA4hJtOkSBNqITT3xEgfLpBtzE/jiuL04RGEBgwWhShRgQExHBAAh+QQJCgAAACwAAAAAIAAgAAAE7xDISWlSqerNpyJKhWRdlSAVoVLCWk6JKlAqAavhO9UkUHsqlE6CwO1cRdCQ8iEIfzFVTzLdRAmZX3I2SfZiCqGk5dTESJeaOAlClzsJsqwiJwiqnFrb2nS9kmIcgEsjQydLiIlHehhpejaIjzh9eomSjZR+ipslWIRLAgMDOR2DOqKogTB9pCUJBagDBXR6XB0EBkIIsaRsGGMMAxoDBgYHTKJiUYEGDAzHC9EACcUGkIgFzgwZ0QsSBcXHiQvOwgDdEwfFs0sDzt4S6BK4xYjkDOzn0unFeBzOBijIm1Dgmg5YFQwsCMjp1oJ8LyIAACH5BAkKAAAALAAAAAAgACAAAATwEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq+E71SRQeyqUToLA7VxF0JDyIQh/MVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiUd6GGl6NoiPOH16iZKNlH6KmyWFOggHhEEvAwwMA0N9GBsEC6amhnVcEwavDAazGwIDaH1ipaYLBUTCGgQDA8NdHz0FpqgTBwsLqAbWAAnIA4FWKdMLGdYGEgraigbT0OITBcg5QwPT4xLrROZL6AuQAPUS7bxLpoWidY0JtxLHKhwwMJBTHgPKdEQAACH5BAkKAAAALAAAAAAgACAAAATrEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq+E71SRQeyqUToLA7VxF0JDyIQh/MVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiUd6GAULDJCRiXo1CpGXDJOUjY+Yip9DhToJA4RBLwMLCwVDfRgbBAaqqoZ1XBMHswsHtxtFaH1iqaoGNgAIxRpbFAgfPQSqpbgGBqUD1wBXeCYp1AYZ19JJOYgH1KwA4UBvQwXUBxPqVD9L3sbp2BNk2xvvFPJd+MFCN6HAAIKgNggY0KtEBAAh+QQJCgAAACwAAAAAIAAgAAAE6BDISWlSqerNpyJKhWRdlSAVoVLCWk6JKlAqAavhO9UkUHsqlE6CwO1cRdCQ8iEIfzFVTzLdRAmZX3I2SfYIDMaAFdTESJeaEDAIMxYFqrOUaNW4E4ObYcCXaiBVEgULe0NJaxxtYksjh2NLkZISgDgJhHthkpU4mW6blRiYmZOlh4JWkDqILwUGBnE6TYEbCgevr0N1gH4At7gHiRpFaLNrrq8HNgAJA70AWxQIH1+vsYMDAzZQPC9VCNkDWUhGkuE5PxJNwiUK4UfLzOlD4WvzAHaoG9nxPi5d+jYUqfAhhykOFwJWiAAAIfkECQoAAAAsAAAAACAAIAAABPAQyElpUqnqzaciSoVkXVUMFaFSwlpOCcMYlErAavhOMnNLNo8KsZsMZItJEIDIFSkLGQoQTNhIsFehRww2CQLKF0tYGKYSg+ygsZIuNqJksKgbfgIGepNo2cIUB3V1B3IvNiBYNQaDSTtfhhx0CwVPI0UJe0+bm4g5VgcGoqOcnjmjqDSdnhgEoamcsZuXO1aWQy8KAwOAuTYYGwi7w5h+Kr0SJ8MFihpNbx+4Erq7BYBuzsdiH1jCAzoSfl0rVirNbRXlBBlLX+BP0XJLAPGzTkAuAOqb0WT5AH7OcdCm5B8TgRwSRKIHQtaLCwg1RAAAOwAAAAAAAAAAAA==); }
 
-/* line 2293, ../../sass/_elements.sass */
 .jvectormap-legend-title {
   font-weight: bold;
   font-size: 14px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 2299, ../../sass/_elements.sass */
 .jvectormap-legend-cnt {
-  position: absolute;
-}
+  position: absolute; }
 
-/* line 2303, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-h {
   bottom: 0;
-  right: 0;
-}
+  right: 0; }
 
-/* line 2308, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-v {
   top: 0;
-  right: 0;
-}
+  right: 0; }
 
-/* line 2313, ../../sass/_elements.sass */
 .jvectormap-legend {
   background: black;
   color: white;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 2319, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-h .jvectormap-legend {
   float: left;
   margin: 0 10px 10px 0;
-  padding: 3px 3px 1px 3px;
-}
+  padding: 3px 3px 1px 3px; }
 
-/* line 2325, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-h .jvectormap-legend .jvectormap-legend-tick {
-  float: left;
-}
+  float: left; }
 
-/* line 2329, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-v .jvectormap-legend {
   margin: 10px 10px 0 0;
-  padding: 3px;
-}
+  padding: 3px; }
 
-/* line 2334, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-h .jvectormap-legend-tick {
-  width: 40px;
-}
+  width: 40px; }
 
-/* line 2338, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-h .jvectormap-legend-tick-sample {
-  height: 15px;
-}
+  height: 15px; }
 
-/* line 2342, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-v .jvectormap-legend-tick-sample {
   height: 20px;
   width: 20px;
   display: inline-block;
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
-/* line 2349, ../../sass/_elements.sass */
 .jvectormap-legend-tick-text {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 2353, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-h .jvectormap-legend-tick-text {
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 2357, ../../sass/_elements.sass */
 .jvectormap-legend-cnt-v .jvectormap-legend-tick-text {
   display: inline-block;
   vertical-align: middle;
   line-height: 20px;
-  padding-left: 3px;
-}
+  padding-left: 3px; }
 
 /*Slick Carousel */
-/* line 2366, ../../sass/_elements.sass */
 .slick-prev:before,
 .slick-next:before {
-  color: #1ab394 !important;
-}
+  color: #1ab394 !important; }
 
 /* Payments */
-/* line 2373, ../../sass/_elements.sass */
 .payment-card {
   background: #ffffff;
   padding: 20px;
   margin-bottom: 25px;
-  border: 1px solid #e7eaec;
-}
+  border: 1px solid #e7eaec; }
 
-/* line 2380, ../../sass/_elements.sass */
 .payment-icon-big {
   font-size: 60px;
-  color: #D1DADE;
-}
+  color: #D1DADE; }
 
-/* line 2385, ../../sass/_elements.sass */
 .payments-method.panel-group .panel + .panel {
-  margin-top: -1px;
-}
+  margin-top: -1px; }
 
-/* line 2389, ../../sass/_elements.sass */
 .payments-method .panel-heading {
-  padding: 15px;
-}
+  padding: 15px; }
 
-/* line 2393, ../../sass/_elements.sass */
 .payments-method .panel {
-  border-radius: 0;
-}
+  border-radius: 0; }
 
-/* line 2397, ../../sass/_elements.sass */
 .payments-method .panel-heading h5 {
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
-/* line 2401, ../../sass/_elements.sass */
 .payments-method .panel-heading i {
-  font-size: 26px;
-}
+  font-size: 26px; }
 
 /* Select2 custom styles */
-/* line 2407, ../../sass/_elements.sass */
 .select2-container--default .select2-selection--single,
 .select2-container--default .select2-selection--multiple {
-  border-color: #e7eaec;
-}
+  border-color: #e7eaec; }
 
-/* line 2411, ../../sass/_elements.sass */
 .select2-container--default.select2-container--focus .select2-selection--single,
 .select2-container--default.select2-container--focus .select2-selection--multiple {
-  border-color: #1ab394;
-}
+  border-color: #1ab394; }
 
-/* line 2415, ../../sass/_elements.sass */
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
-  background-color: #1ab394;
-}
+  background-color: #1ab394; }
 
-/* line 2418, ../../sass/_elements.sass */
 .select2-container--default .select2-search--dropdown .select2-search__field {
-  border-color: #e7eaec;
-}
+  border-color: #e7eaec; }
 
-/* line 2421, ../../sass/_elements.sass */
 .select2-dropdown {
-  border-color: #e7eaec;
-}
-/* line 2424, ../../sass/_elements.sass */
-.select2-dropdown input:focus {
-  outline: none;
-}
+  border-color: #e7eaec; }
+  .select2-dropdown input:focus {
+    outline: none; }
 
-/* line 2428, ../../sass/_elements.sass */
 .select2-selection {
-  outline: none;
-}
+  outline: none; }
 
-/* line 2431, ../../sass/_elements.sass */
 .ui-select-container.ui-select-bootstrap .ui-select-choices-row.active > a {
-  background-color: #1ab394;
-}
+  background-color: #1ab394; }
 
 /* Tour */
-/* line 2437, ../../sass/_elements.sass */
 .tour-tour .btn.btn-default {
   background-color: #ffffff;
   border: 1px solid #d2d2d2;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 2443, ../../sass/_elements.sass */
 .tour-step-backdrop {
-  z-index: 2101;
-}
+  z-index: 2101; }
 
-/* line 2447, ../../sass/_elements.sass */
 .tour-backdrop {
   z-index: 2100;
-  opacity: 0.7;
-}
+  opacity: 0.7; }
 
-/* line 2452, ../../sass/_elements.sass */
 .popover[class*=tour-] {
-  z-index: 2100;
-}
+  z-index: 2100; }
 
-/* line 2456, ../../sass/_elements.sass */
 body.tour-open .animated {
-  animation-fill-mode: initial;
-}
+  animation-fill-mode: initial; }
 
 /* Activity stream */
-/* line 2462, ../../sass/_elements.sass */
 .stream {
   position: relative;
-  padding: 10px 0;
-}
-/* line 2467, ../../sass/_elements.sass */
-.stream:first-child .stream-badge:before {
-  top: 10px;
-}
-/* line 2470, ../../sass/_elements.sass */
-.stream:last-child .stream-badge:before {
-  height: 30px;
-}
-/* line 2473, ../../sass/_elements.sass */
-.stream .stream-badge {
-  width: 50px;
-}
-/* line 2476, ../../sass/_elements.sass */
-.stream .stream-badge i {
-  border: 1px solid #e7eaec;
-  border-radius: 50%;
-  padding: 6px;
-  color: #808486;
-  position: absolute;
-  background-color: #ffffff;
-  left: 8px;
-}
-/* line 2485, ../../sass/_elements.sass */
-.stream .stream-badge i.fa-circle {
-  color: #ced0d1;
-}
-/* line 2488, ../../sass/_elements.sass */
-.stream .stream-badge i.bg-success {
-  color: #ffffff;
-  background-color: #1c84c6;
-  border-color: #1c84c6;
-}
-/* line 2493, ../../sass/_elements.sass */
-.stream .stream-badge i.bg-primary {
-  color: #ffffff;
-  background-color: #1ab394;
-  border-color: #1ab394;
-}
-/* line 2498, ../../sass/_elements.sass */
-.stream .stream-badge i.bg-warning {
-  color: #ffffff;
-  background-color: #f8ac59;
-  border-color: #f8ac59;
-}
-/* line 2503, ../../sass/_elements.sass */
-.stream .stream-badge i.bg-info {
-  color: #ffffff;
-  background-color: #23c6c8;
-  border-color: #23c6c8;
-}
-/* line 2508, ../../sass/_elements.sass */
-.stream .stream-badge i.bg-danger {
-  color: #ffffff;
-  background-color: #ED5565;
-  border-color: #ED5565;
-}
-/* line 2514, ../../sass/_elements.sass */
-.stream .stream-badge:before {
-  content: "";
-  width: 1px;
-  background-color: #e7eaec;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 20px;
-}
-/* line 2524, ../../sass/_elements.sass */
-.stream .stream-info {
-  font-size: 12px;
-  margin-bottom: 5px;
-}
-/* line 2528, ../../sass/_elements.sass */
-.stream .stream-info img {
-  border-radius: 50%;
-  width: 18px;
-  height: 18px;
-  margin-right: 2px;
-  margin-top: -4px;
-}
-/* line 2536, ../../sass/_elements.sass */
-.stream .stream-info .date {
-  color: #9a9d9f;
-  font-size: 80%;
-}
-/* line 2541, ../../sass/_elements.sass */
-.stream .stream-panel {
-  margin-left: 55px;
-}
+  padding: 10px 0; }
+  .stream:first-child .stream-badge:before {
+    top: 10px; }
+  .stream:last-child .stream-badge:before {
+    height: 30px; }
+  .stream .stream-badge {
+    width: 50px; }
+    .stream .stream-badge i {
+      border: 1px solid #e7eaec;
+      border-radius: 50%;
+      padding: 6px;
+      color: #808486;
+      position: absolute;
+      background-color: #ffffff;
+      left: 8px; }
+      .stream .stream-badge i.fa-circle {
+        color: #ced0d1; }
+      .stream .stream-badge i.bg-success {
+        color: #ffffff;
+        background-color: #1c84c6;
+        border-color: #1c84c6; }
+      .stream .stream-badge i.bg-primary {
+        color: #ffffff;
+        background-color: #1ab394;
+        border-color: #1ab394; }
+      .stream .stream-badge i.bg-warning {
+        color: #ffffff;
+        background-color: #f8ac59;
+        border-color: #f8ac59; }
+      .stream .stream-badge i.bg-info {
+        color: #ffffff;
+        background-color: #23c6c8;
+        border-color: #23c6c8; }
+      .stream .stream-badge i.bg-danger {
+        color: #ffffff;
+        background-color: #ED5565;
+        border-color: #ED5565; }
+    .stream .stream-badge:before {
+      content: "";
+      width: 1px;
+      background-color: #e7eaec;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 20px; }
+  .stream .stream-info {
+    font-size: 12px;
+    margin-bottom: 5px; }
+    .stream .stream-info img {
+      border-radius: 50%;
+      width: 18px;
+      height: 18px;
+      margin-right: 2px;
+      margin-top: -4px; }
+    .stream .stream-info .date {
+      color: #9a9d9f;
+      font-size: 80%; }
+  .stream .stream-panel {
+    margin-left: 55px; }
 
-/* line 2545, ../../sass/_elements.sass */
 .stream-small {
-  margin: 10px 0;
-}
-/* line 2548, ../../sass/_elements.sass */
-.stream-small .label {
-  padding: 2px 6px;
-  margin-right: 2px;
-}
+  margin: 10px 0; }
+  .stream-small .label {
+    padding: 2px 6px;
+    margin-right: 2px; }
 
-/* line 1, ../../sass/_sidebar.sass */
 .sidebar-panel {
   width: 220px;
   background: #ebebed;
   padding: 10px 20px;
   position: absolute;
-  right: 0;
-}
+  right: 0; }
 
-/* line 9, ../../sass/_sidebar.sass */
 .sidebar-panel .feed-element img.img-circle {
   width: 32px;
-  height: 32px;
-}
+  height: 32px; }
 
-/* line 14, ../../sass/_sidebar.sass */
 .sidebar-panel .feed-element, .media-body, .sidebar-panel p {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 18, ../../sass/_sidebar.sass */
 .sidebar-panel .feed-element {
   margin-top: 20px;
-  padding-bottom: 0;
-}
+  padding-bottom: 0; }
 
-/* line 23, ../../sass/_sidebar.sass */
 .sidebar-panel .list-group {
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 27, ../../sass/_sidebar.sass */
 .sidebar-panel .list-group .list-group-item {
   padding: 5px 0;
   font-size: 12px;
-  border: 0;
-}
+  border: 0; }
 
-/* line 33, ../../sass/_sidebar.sass */
 .sidebar-content .wrapper, .wrapper.sidebar-content {
-  padding-right: 230px !important;
-}
+  padding-right: 230px !important; }
 
-/* line 37, ../../sass/_sidebar.sass */
 .body-small .sidebar-content .wrapper, .body-small .wrapper.sidebar-content {
-  padding-right: 20px !important;
-}
+  padding-right: 20px !important; }
 
-/* line 43, ../../sass/_sidebar.sass */
 #right-sidebar {
   background-color: #fff;
   border-left: 1px solid #e7eaec;
@@ -4290,41 +2958,25 @@ body.tour-open .animated {
   width: 260px !important;
   z-index: 1009;
   bottom: 0;
-  right: -260px;
-}
+  right: -260px; }
 
-/* line 56, ../../sass/_sidebar.sass */
 #right-sidebar.sidebar-open {
-  right: 0;
-}
+  right: 0; }
 
-/* line 60, ../../sass/_sidebar.sass */
 #right-sidebar.sidebar-open.sidebar-top {
   top: 0;
-  border-top: none;
-}
+  border-top: none; }
 
-/* line 67, ../../sass/_sidebar.sass */
 .sidebar-container ul.nav-tabs {
-  border: none;
-}
-/* line 71, ../../sass/_sidebar.sass */
+  border: none; }
 .sidebar-container ul.nav-tabs.navs-4 li {
-  width: 25%;
-}
-/* line 74, ../../sass/_sidebar.sass */
+  width: 25%; }
 .sidebar-container ul.nav-tabs.navs-3 li {
-  width: 33.3333%;
-}
-/* line 77, ../../sass/_sidebar.sass */
+  width: 33.3333%; }
 .sidebar-container ul.nav-tabs.navs-2 li {
-  width: 50%;
-}
-/* line 81, ../../sass/_sidebar.sass */
+  width: 50%; }
 .sidebar-container ul.nav-tabs li {
-  border: none;
-}
-/* line 85, ../../sass/_sidebar.sass */
+  border: none; }
 .sidebar-container ul.nav-tabs li a {
   border: none;
   padding: 12px 10px;
@@ -4333,259 +2985,169 @@ body.tour-open .animated {
   background: #2F4050;
   color: #fff;
   text-align: center;
-  border-right: 1px solid #334556;
-}
-/* line 97, ../../sass/_sidebar.sass */
+  border-right: 1px solid #334556; }
 .sidebar-container ul.nav-tabs li.active a {
   border: none;
   background: #f9f9f9;
   color: #676a6c;
-  font-weight: bold;
-}
-/* line 105, ../../sass/_sidebar.sass */
+  font-weight: bold; }
 .sidebar-container .nav-tabs > li.active > a:hover,
 .sidebar-container .nav-tabs > li.active > a:focus {
-  border: none;
-}
-/* line 112, ../../sass/_sidebar.sass */
+  border: none; }
 .sidebar-container ul.sidebar-list {
   margin: 0;
-  padding: 0;
-}
-/* line 117, ../../sass/_sidebar.sass */
+  padding: 0; }
 .sidebar-container ul.sidebar-list li {
   border-bottom: 1px solid #e7eaec;
   padding: 15px 20px;
   list-style: none;
-  font-size: 12px;
-}
-/* line 129, ../../sass/_sidebar.sass */
+  font-size: 12px; }
 .sidebar-container .sidebar-message:nth-child(2n+2) {
-  background: #f9f9f9;
-}
-/* line 133, ../../sass/_sidebar.sass */
+  background: #f9f9f9; }
 .sidebar-container ul.sidebar-list li a {
   text-decoration: none;
-  color: inherit;
-}
-/* line 138, ../../sass/_sidebar.sass */
+  color: inherit; }
 .sidebar-container .sidebar-content {
   padding: 15px 20px;
-  font-size: 12px;
-}
-/* line 143, ../../sass/_sidebar.sass */
+  font-size: 12px; }
 .sidebar-container .sidebar-title {
   background: #f9f9f9;
   padding: 20px;
-  border-bottom: 1px solid #e7eaec;
-}
-/* line 148, ../../sass/_sidebar.sass */
-.sidebar-container .sidebar-title h3 {
-  margin-bottom: 3px;
-  padding-left: 2px;
-}
-/* line 156, ../../sass/_sidebar.sass */
+  border-bottom: 1px solid #e7eaec; }
+  .sidebar-container .sidebar-title h3 {
+    margin-bottom: 3px;
+    padding-left: 2px; }
 .sidebar-container .tab-content h4 {
-  margin-bottom: 5px;
-}
-/* line 162, ../../sass/_sidebar.sass */
+  margin-bottom: 5px; }
 .sidebar-container .sidebar-message > a > .pull-left {
-  margin-right: 10px;
-}
-/* line 166, ../../sass/_sidebar.sass */
+  margin-right: 10px; }
 .sidebar-container .sidebar-message > a {
   text-decoration: none;
-  color: inherit;
-}
-/* line 171, ../../sass/_sidebar.sass */
+  color: inherit; }
 .sidebar-container .sidebar-message {
-  padding: 15px 20px;
-}
-/* line 175, ../../sass/_sidebar.sass */
+  padding: 15px 20px; }
 .sidebar-container .sidebar-message .media-body {
   display: block;
-  width: auto;
-}
-/* line 179, ../../sass/_sidebar.sass */
+  width: auto; }
 .sidebar-container .sidebar-message .message-avatar {
   height: 38px;
   width: 38px;
-  border-radius: 50%;
-}
-/* line 185, ../../sass/_sidebar.sass */
+  border-radius: 50%; }
 .sidebar-container .setings-item {
   padding: 15px 20px;
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 1, ../../sass/_base.sass */
 body {
   font-family: "open sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   background-color: #2f4050;
   font-size: 13px;
   color: #676a6c;
-  overflow-x: hidden;
-}
+  overflow-x: hidden; }
 
-/* line 10, ../../sass/_base.sass */
 html, body {
-  height: 100%;
-}
+  height: 100%; }
 
-/* line 15, ../../sass/_base.sass */
 body.full-height-layout #wrapper,
 body.full-height-layout #page-wrapper {
-  height: 100%;
-}
+  height: 100%; }
 
-/* line 20, ../../sass/_base.sass */
 #page-wrapper {
-  min-height: auto;
-}
+  min-height: auto; }
 
-/* line 24, ../../sass/_base.sass */
 body.boxed-layout {
-  background: url("patterns/shattered.png");
-}
+  background: url("patterns/shattered.png"); }
 
-/* line 28, ../../sass/_base.sass */
 body.boxed-layout #wrapper {
   background-color: #2f4050;
   max-width: 1200px;
   margin: 0 auto;
   -webkit-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.75);
   -moz-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.75);
-  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.75);
-}
+  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.75); }
 
-/* line 37, ../../sass/_base.sass */
 .top-navigation.boxed-layout #wrapper,
 .boxed-layout #wrapper.top-navigation {
-  max-width: 1300px !important;
-}
+  max-width: 1300px !important; }
 
-/* line 42, ../../sass/_base.sass */
 .block {
-  display: block;
-}
+  display: block; }
 
-/* line 46, ../../sass/_base.sass */
 .clear {
   display: block;
-  overflow: hidden;
-}
+  overflow: hidden; }
 
-/* line 51, ../../sass/_base.sass */
 a {
-  cursor: pointer;
-}
+  cursor: pointer; }
 
-/* line 55, ../../sass/_base.sass */
 a:hover, a:focus {
-  text-decoration: none;
-}
+  text-decoration: none; }
 
-/* line 59, ../../sass/_base.sass */
 .border-bottom {
-  border-bottom: 1px solid #e7eaec !important;
-}
+  border-bottom: 1px solid #e7eaec !important; }
 
-/* line 63, ../../sass/_base.sass */
 .font-bold {
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 67, ../../sass/_base.sass */
 .font-normal {
-  font-weight: 400;
-}
+  font-weight: 400; }
 
-/* line 71, ../../sass/_base.sass */
 .text-uppercase {
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
-/* line 74, ../../sass/_base.sass */
 .font-italic {
-  font-style: italic;
-}
+  font-style: italic; }
 
-/* line 77, ../../sass/_base.sass */
 .b-r {
-  border-right: 1px solid #e7eaec;
-}
+  border-right: 1px solid #e7eaec; }
 
-/* line 81, ../../sass/_base.sass */
 .hr-line-dashed {
   border-top: 1px dashed #e7eaec;
   color: #ffffff;
   background-color: #ffffff;
   height: 1px;
-  margin: 20px 0;
-}
+  margin: 20px 0; }
 
-/* line 89, ../../sass/_base.sass */
 .hr-line-solid {
   border-bottom: 1px solid #e7eaec;
   background-color: transparent;
   border-style: solid !important;
   margin-top: 15px;
-  margin-bottom: 15px;
-}
+  margin-bottom: 15px; }
 
-/* line 97, ../../sass/_base.sass */
 video {
   width: 100% !important;
-  height: auto !important;
-}
+  height: auto !important; }
 
 /* GALLERY */
-/* line 103, ../../sass/_base.sass */
 .gallery > .row > div {
-  margin-bottom: 15px;
-}
+  margin-bottom: 15px; }
 
-/* line 107, ../../sass/_base.sass */
 .fancybox img {
   margin-bottom: 5px;
   /* Only for demo */
-  width: 24%;
-}
+  width: 24%; }
 
 /* Summernote text editor  */
-/* line 114, ../../sass/_base.sass */
 .note-editor {
-  height: auto !important;
-}
+  height: auto !important; }
 
-/* line 118, ../../sass/_base.sass */
 .note-editor.fullscreen {
-  z-index: 2050;
-}
+  z-index: 2050; }
 
-/* line 121, ../../sass/_base.sass */
 .note-editor.note-frame.fullscreen {
-  z-index: 2020;
-}
+  z-index: 2020; }
 
-/* line 124, ../../sass/_base.sass */
 .note-editor.note-frame .note-editing-area .note-editable {
   color: #676a6c;
-  padding: 15px;
-}
+  padding: 15px; }
 
-/* line 128, ../../sass/_base.sass */
 .note-editor.note-frame {
-  border: none;
-}
+  border: none; }
 
-/* line 131, ../../sass/_base.sass */
 .note-editor.panel {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
 /* MODAL */
-/* line 136, ../../sass/_base.sass */
 .modal-content {
   background-clip: padding-box;
   background-color: #FFFFFF;
@@ -4593,112 +3155,75 @@ video {
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   outline: 0 none;
-  position: relative;
-}
+  position: relative; }
 
-/* line 146, ../../sass/_base.sass */
 .modal-dialog {
-  z-index: 2200;
-}
+  z-index: 2200; }
 
-/* line 150, ../../sass/_base.sass */
 .modal-body {
-  padding: 20px 30px 30px 30px;
-}
+  padding: 20px 30px 30px 30px; }
 
-/* line 154, ../../sass/_base.sass */
 .inmodal .modal-body {
-  background: #f8fafb;
-}
+  background: #f8fafb; }
 
-/* line 158, ../../sass/_base.sass */
 .inmodal .modal-header {
   padding: 30px 15px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 163, ../../sass/_base.sass */
 .animated.modal.fade .modal-dialog {
   -webkit-transform: none;
   -ms-transform: none;
   -o-transform: none;
-  transform: none;
-}
+  transform: none; }
 
-/* line 170, ../../sass/_base.sass */
 .inmodal .modal-title {
-  font-size: 26px;
-}
+  font-size: 26px; }
 
-/* line 174, ../../sass/_base.sass */
 .inmodal .modal-icon {
   font-size: 84px;
-  color: #e2e3e3;
-}
+  color: #e2e3e3; }
 
-/* line 179, ../../sass/_base.sass */
 .modal-footer {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
 /* WRAPPERS */
-/* line 185, ../../sass/_base.sass */
 #wrapper {
   width: 100%;
-  overflow-x: hidden;
-}
+  overflow-x: hidden; }
 
-/* line 190, ../../sass/_base.sass */
 .wrapper {
-  padding: 0 20px;
-}
+  padding: 0 20px; }
 
-/* line 194, ../../sass/_base.sass */
 .wrapper-content {
-  padding: 20px 10px 40px;
-}
+  padding: 20px 10px 40px; }
 
-/* line 198, ../../sass/_base.sass */
 #page-wrapper {
   padding: 0 15px;
   min-height: 568px;
-  position: relative !important;
-}
+  position: relative !important; }
 
 @media (min-width: 768px) {
-  /* line 205, ../../sass/_base.sass */
   #page-wrapper {
     position: inherit;
     margin: 0 0 0 240px;
-    min-height: 2002px;
-  }
-}
-/* line 212, ../../sass/_base.sass */
+    min-height: 2002px; } }
 .title-action {
   text-align: right;
-  padding-top: 30px;
-}
+  padding-top: 30px; }
 
-/* line 217, ../../sass/_base.sass */
 .ibox-content h1, .ibox-content h2, .ibox-content h3, .ibox-content h4, .ibox-content h5,
 .ibox-title h1, .ibox-title h2, .ibox-title h3, .ibox-title h4, .ibox-title h5 {
-  margin-top: 5px;
-}
+  margin-top: 5px; }
 
-/* line 222, ../../sass/_base.sass */
 ul.unstyled, ol.unstyled {
   list-style: none outside none;
-  margin-left: 0;
-}
+  margin-left: 0; }
 
-/* line 227, ../../sass/_base.sass */
 .big-icon {
   font-size: 160px !important;
-  color: #e5e6e7;
-}
+  color: #e5e6e7; }
 
 /* FOOTER */
-/* line 234, ../../sass/_base.sass */
 .footer {
   background: none repeat scroll 0 0 white;
   border-top: 1px solid #e7eaec;
@@ -4706,10 +3231,8 @@ ul.unstyled, ol.unstyled {
   left: 0;
   padding: 10px 20px;
   position: absolute;
-  right: 0;
-}
+  right: 0; }
 
-/* line 245, ../../sass/_base.sass */
 .footer.fixed_full {
   position: fixed;
   bottom: 0;
@@ -4718,10 +3241,8 @@ ul.unstyled, ol.unstyled {
   z-index: 1000;
   padding: 10px 20px;
   background: white;
-  border-top: 1px solid #e7eaec;
-}
+  border-top: 1px solid #e7eaec; }
 
-/* line 256, ../../sass/_base.sass */
 .footer.fixed {
   position: fixed;
   bottom: 0;
@@ -4731,217 +3252,143 @@ ul.unstyled, ol.unstyled {
   padding: 10px 20px;
   background: white;
   border-top: 1px solid #e7eaec;
-  margin-left: 220px;
-}
+  margin-left: 220px; }
 
-/* line 268, ../../sass/_base.sass */
 body.mini-navbar .footer.fixed,
 body.body-small.mini-navbar .footer.fixed {
-  margin: 0 0 0 70px;
-}
+  margin: 0 0 0 70px; }
 
-/* line 273, ../../sass/_base.sass */
 body.mini-navbar.canvas-menu .footer.fixed,
 body.canvas-menu .footer.fixed {
-  margin: 0 !important;
-}
+  margin: 0 !important; }
 
-/* line 278, ../../sass/_base.sass */
 body.fixed-sidebar.body-small.mini-navbar .footer.fixed {
-  margin: 0 0 0 220px;
-}
+  margin: 0 0 0 220px; }
 
-/* line 282, ../../sass/_base.sass */
 body.body-small .footer.fixed {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
 /* PANELS */
-/* line 288, ../../sass/_base.sass */
 .page-heading {
   border-top: 0;
-  padding: 0 10px 20px 10px;
-}
+  padding: 0 10px 20px 10px; }
 
-/* line 293, ../../sass/_base.sass */
 .panel-heading h1, .panel-heading h2 {
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
 /* TABLES */
-/* line 299, ../../sass/_base.sass */
 .table-bordered {
-  border: 1px solid #EBEBEB;
-}
+  border: 1px solid #EBEBEB; }
 
-/* line 303, ../../sass/_base.sass */
 .table-bordered > thead > tr > th, .table-bordered > thead > tr > td {
   background-color: #F5F5F6;
-  border-bottom-width: 1px;
-}
+  border-bottom-width: 1px; }
 
-/* line 308, ../../sass/_base.sass */
 .table-bordered > thead > tr > th, .table-bordered > tbody > tr > th, .table-bordered > tfoot > tr > th, .table-bordered > thead > tr > td, .table-bordered > tbody > tr > td, .table-bordered > tfoot > tr > td {
-  border: 1px solid #e7e7e7;
-}
+  border: 1px solid #e7e7e7; }
 
-/* line 312, ../../sass/_base.sass */
 .table > thead > tr > th {
   border-bottom: 1px solid #DDDDDD;
-  vertical-align: bottom;
-}
+  vertical-align: bottom; }
 
-/* line 317, ../../sass/_base.sass */
 .table > thead > tr > th, .table > tbody > tr > th, .table > tfoot > tr > th, .table > thead > tr > td, .table > tbody > tr > td, .table > tfoot > tr > td {
   border-top: 1px solid #e7eaec;
   line-height: 1.42857;
   padding: 8px;
-  vertical-align: top;
-}
+  vertical-align: top; }
 
 /* PANELS */
-/* line 326, ../../sass/_base.sass */
 .panel.blank-panel {
   background: none;
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 331, ../../sass/_base.sass */
 .blank-panel .panel-heading {
-  padding-bottom: 0;
-}
+  padding-bottom: 0; }
 
-/* line 335, ../../sass/_base.sass */
 .nav-tabs > li > a {
   color: #A7B1C2;
   font-weight: 600;
-  padding: 10px 20px 10px 25px;
-}
+  padding: 10px 20px 10px 25px; }
 
-/* line 341, ../../sass/_base.sass */
 .nav-tabs > li > a:hover, .nav-tabs > li > a:focus {
   background-color: #e6e6e6;
-  color: #676a6c;
-}
+  color: #676a6c; }
 
-/* line 346, ../../sass/_base.sass */
 .ui-tab .tab-content {
-  padding: 20px 0;
-}
+  padding: 20px 0; }
 
 /* GLOBAL  */
-/* line 352, ../../sass/_base.sass */
 .no-padding {
-  padding: 0 !important;
-}
+  padding: 0 !important; }
 
-/* line 356, ../../sass/_base.sass */
 .no-borders {
-  border: none !important;
-}
+  border: none !important; }
 
-/* line 360, ../../sass/_base.sass */
 .no-margins {
-  margin: 0 !important;
-}
+  margin: 0 !important; }
 
-/* line 364, ../../sass/_base.sass */
 .no-top-border {
-  border-top: 0 !important;
-}
+  border-top: 0 !important; }
 
-/* line 368, ../../sass/_base.sass */
 .ibox-content.text-box {
   padding-bottom: 0;
-  padding-top: 15px;
-}
+  padding-top: 15px; }
 
-/* line 373, ../../sass/_base.sass */
 .border-left-right {
   border-left: 1px solid #e7eaec;
-  border-right: 1px solid #e7eaec;
-}
+  border-right: 1px solid #e7eaec; }
 
-/* line 378, ../../sass/_base.sass */
 .border-left {
   border-left: 1px solid #e7eaec;
   border-right: none;
   border-top: none;
-  border-bottom: none;
-}
+  border-bottom: none; }
 
-/* line 385, ../../sass/_base.sass */
 .border-right {
   border-left: none;
   border-right: 1px solid #e7eaec;
   border-top: none;
-  border-bottom: none;
-}
+  border-bottom: none; }
 
-/* line 391, ../../sass/_base.sass */
 .border-top {
-  border-top: 1px solid #e7eaec;
-}
+  border-top: 1px solid #e7eaec; }
 
-/* line 395, ../../sass/_base.sass */
 .border-bottom {
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 399, ../../sass/_base.sass */
 .border-size-sm {
-  border-width: 3px;
-}
+  border-width: 3px; }
 
-/* line 403, ../../sass/_base.sass */
 .border-size-md {
-  border-width: 6px;
-}
+  border-width: 6px; }
 
-/* line 407, ../../sass/_base.sass */
 .border-size-lg {
-  border-width: 9px;
-}
+  border-width: 9px; }
 
-/* line 411, ../../sass/_base.sass */
 .border-size-xl {
-  border-width: 12px;
-}
+  border-width: 12px; }
 
-/* line 415, ../../sass/_base.sass */
 .full-width {
-  width: 100% !important;
-}
+  width: 100% !important; }
 
-/* line 419, ../../sass/_base.sass */
 .link-block {
   font-size: 12px;
-  padding: 10px;
-}
+  padding: 10px; }
 
-/* line 424, ../../sass/_base.sass */
 .nav.navbar-top-links .link-block a {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 428, ../../sass/_base.sass */
 .link-block a {
   font-size: 10px;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 434, ../../sass/_base.sass */
 body.mini-navbar .branding {
-  display: none;
-}
+  display: none; }
 
-/* line 438, ../../sass/_base.sass */
 img.circle-border {
   border: 6px solid #FFFFFF;
-  border-radius: 50%;
-}
+  border-radius: 50%; }
 
-/* line 443, ../../sass/_base.sass */
 .branding {
   float: left;
   color: #FFFFFF;
@@ -4949,100 +3396,68 @@ img.circle-border {
   font-weight: 600;
   padding: 17px 20px;
   text-align: center;
-  background-color: #1ab394;
-}
+  background-color: #1ab394; }
 
-/* line 453, ../../sass/_base.sass */
 .login-panel {
-  margin-top: 25%;
-}
+  margin-top: 25%; }
 
-/* line 457, ../../sass/_base.sass */
 .icons-box h3 {
   margin-top: 10px;
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 462, ../../sass/_base.sass */
 .icons-box .infont a i {
   font-size: 25px;
   display: block;
-  color: #676a6c;
-}
+  color: #676a6c; }
 
-/* line 468, ../../sass/_base.sass */
 .icons-box .infont a {
-  color: #a6a8a9;
-}
+  color: #a6a8a9; }
 
-/* line 472, ../../sass/_base.sass */
 .icons-box .infont a {
   padding: 10px;
   margin: 1px;
-  display: block;
-}
+  display: block; }
 
-/* line 479, ../../sass/_base.sass */
 .ui-draggable .ibox-title {
-  cursor: move;
-}
+  cursor: move; }
 
-/* line 483, ../../sass/_base.sass */
 .breadcrumb {
   background-color: #ffffff;
   padding: 0;
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 489, ../../sass/_base.sass */
 .breadcrumb > li a {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 493, ../../sass/_base.sass */
 .breadcrumb > .active {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 497, ../../sass/_base.sass */
 code {
   background-color: #F9F2F4;
   border-radius: 4px;
   color: #ca4440;
   font-size: 90%;
   padding: 2px 4px;
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
-/* line 506, ../../sass/_base.sass */
 .ibox {
   clear: both;
   margin-bottom: 25px;
   margin-top: 0;
-  padding: 0;
-}
+  padding: 0; }
 
-/* line 513, ../../sass/_base.sass */
 .ibox.collapsed .ibox-content {
-  display: none;
-}
+  display: none; }
 
-/* line 517, ../../sass/_base.sass */
 .ibox.collapsed .fa.fa-chevron-up:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 521, ../../sass/_base.sass */
 .ibox.collapsed .fa.fa-chevron-down:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 525, ../../sass/_base.sass */
 .ibox:after, .ibox:before {
-  display: table;
-}
+  display: table; }
 
-/* line 529, ../../sass/_base.sass */
 .ibox-title {
   -moz-border-bottom-colors: none;
   -moz-border-left-colors: none;
@@ -5056,10 +3471,8 @@ code {
   color: inherit;
   margin-bottom: 0;
   padding: 15px 15px 7px;
-  min-height: 48px;
-}
+  min-height: 48px; }
 
-/* line 545, ../../sass/_base.sass */
 .ibox-content {
   background-color: #ffffff;
   color: inherit;
@@ -5067,331 +3480,217 @@ code {
   border-color: #e7eaec;
   border-image: none;
   border-style: solid solid none;
-  border-width: 1px 0;
-}
+  border-width: 1px 0; }
 
-/* line 556, ../../sass/_base.sass */
 .ibox-footer {
   color: inherit;
   border-top: 1px solid #e7eaec;
   font-size: 90%;
   background: #ffffff;
-  padding: 10px 15px;
-}
+  padding: 10px 15px; }
 
-/* line 564, ../../sass/_base.sass */
 table.table-mail tr td {
-  padding: 12px;
-}
+  padding: 12px; }
 
-/* line 568, ../../sass/_base.sass */
 .table-mail .check-mail {
-  padding-left: 20px;
-}
+  padding-left: 20px; }
 
-/* line 572, ../../sass/_base.sass */
 .table-mail .mail-date {
-  padding-right: 20px;
-}
+  padding-right: 20px; }
 
-/* line 576, ../../sass/_base.sass */
 .star-mail, .check-mail {
-  width: 40px;
-}
+  width: 40px; }
 
-/* line 580, ../../sass/_base.sass */
 .unread td a, .unread td {
   font-weight: 600;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 585, ../../sass/_base.sass */
 .read td a, .read td {
   font-weight: normal;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 590, ../../sass/_base.sass */
 .unread td {
-  background-color: #f9f8f8;
-}
+  background-color: #f9f8f8; }
 
-/* line 594, ../../sass/_base.sass */
 .ibox-content {
-  clear: both;
-}
+  clear: both; }
 
-/* line 598, ../../sass/_base.sass */
 .ibox-heading {
   background-color: #f3f6fb;
-  border-bottom: none;
-}
+  border-bottom: none; }
 
-/* line 603, ../../sass/_base.sass */
 .ibox-heading h3 {
   font-weight: 200;
-  font-size: 24px;
-}
+  font-size: 24px; }
 
-/* line 608, ../../sass/_base.sass */
 .ibox-title h5 {
   display: inline-block;
   font-size: 14px;
   margin: 0 0 7px;
   padding: 0;
   text-overflow: ellipsis;
-  float: left;
-}
+  float: left; }
 
-/* line 617, ../../sass/_base.sass */
 .ibox-title .label {
   float: left;
-  margin-left: 4px;
-}
+  margin-left: 4px; }
 
-/* line 622, ../../sass/_base.sass */
 .ibox-tools {
   display: block;
   float: none;
   margin-top: 0;
   position: relative;
   padding: 0;
-  text-align: right;
-}
+  text-align: right; }
 
-/* line 631, ../../sass/_base.sass */
 .ibox-tools a {
   cursor: pointer;
   margin-left: 5px;
-  color: #c4c4c4;
-}
+  color: #c4c4c4; }
 
-/* line 637, ../../sass/_base.sass */
 .ibox-tools a.btn-primary {
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 641, ../../sass/_base.sass */
 .ibox-tools .dropdown-menu > li > a {
   padding: 4px 10px;
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 646, ../../sass/_base.sass */
 .ibox .ibox-tools.open > .dropdown-menu {
   left: auto;
-  right: 0;
-}
+  right: 0; }
 
 /* BACKGROUNDS */
-/* line 653, ../../sass/_base.sass */
 .gray-bg, .bg-muted {
-  background-color: #f3f3f4;
-}
+  background-color: #f3f3f4; }
 
-/* line 657, ../../sass/_base.sass */
 .white-bg {
-  background-color: #ffffff;
-}
+  background-color: #ffffff; }
 
-/* line 661, ../../sass/_base.sass */
 .blue-bg, .bg-success {
   background-color: #1c84c6;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 666, ../../sass/_base.sass */
 .navy-bg, .bg-primary {
   background-color: #1ab394;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 671, ../../sass/_base.sass */
 .lazur-bg, .bg-warning {
   background-color: #23c6c8;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 676, ../../sass/_base.sass */
 .yellow-bg {
   background-color: #f8ac59;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 681, ../../sass/_base.sass */
 .red-bg, .bg-danger {
   background-color: #ED5565;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 686, ../../sass/_base.sass */
 .black-bg {
-  background-color: #262626;
-}
+  background-color: #262626; }
 
-/* line 690, ../../sass/_base.sass */
 .panel-primary {
-  border-color: #1ab394;
-}
+  border-color: #1ab394; }
 
-/* line 694, ../../sass/_base.sass */
 .panel-primary > .panel-heading {
   background-color: #1ab394;
-  border-color: #1ab394;
-}
+  border-color: #1ab394; }
 
-/* line 699, ../../sass/_base.sass */
 .panel-success {
-  border-color: #1c84c6;
-}
+  border-color: #1c84c6; }
 
-/* line 703, ../../sass/_base.sass */
 .panel-success > .panel-heading {
   background-color: #1c84c6;
   border-color: #1c84c6;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 709, ../../sass/_base.sass */
 .panel-info {
-  border-color: #23c6c8;
-}
+  border-color: #23c6c8; }
 
-/* line 713, ../../sass/_base.sass */
 .panel-info > .panel-heading {
   background-color: #23c6c8;
   border-color: #23c6c8;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 719, ../../sass/_base.sass */
 .panel-warning {
-  border-color: #f8ac59;
-}
+  border-color: #f8ac59; }
 
-/* line 723, ../../sass/_base.sass */
 .panel-warning > .panel-heading {
   background-color: #f8ac59;
   border-color: #f8ac59;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 729, ../../sass/_base.sass */
 .panel-danger {
-  border-color: #ED5565;
-}
+  border-color: #ED5565; }
 
-/* line 733, ../../sass/_base.sass */
 .panel-danger > .panel-heading {
   background-color: #ED5565;
   border-color: #ED5565;
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 739, ../../sass/_base.sass */
 .progress-bar {
-  background-color: #1ab394;
-}
+  background-color: #1ab394; }
 
-/* line 743, ../../sass/_base.sass */
 .progress-small, .progress-small .progress-bar {
-  height: 10px;
-}
+  height: 10px; }
 
-/* line 747, ../../sass/_base.sass */
 .progress-small, .progress-mini {
-  margin-top: 5px;
-}
+  margin-top: 5px; }
 
-/* line 751, ../../sass/_base.sass */
 .progress-mini, .progress-mini .progress-bar {
   height: 5px;
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 756, ../../sass/_base.sass */
 .progress-bar-navy-light {
-  background-color: #3dc7ab;
-}
+  background-color: #3dc7ab; }
 
-/* line 760, ../../sass/_base.sass */
 .progress-bar-success {
-  background-color: #1c84c6;
-}
+  background-color: #1c84c6; }
 
-/* line 764, ../../sass/_base.sass */
 .progress-bar-info {
-  background-color: #23c6c8;
-}
+  background-color: #23c6c8; }
 
-/* line 768, ../../sass/_base.sass */
 .progress-bar-warning {
-  background-color: #f8ac59;
-}
+  background-color: #f8ac59; }
 
-/* line 772, ../../sass/_base.sass */
 .progress-bar-danger {
-  background-color: #ED5565;
-}
+  background-color: #ED5565; }
 
-/* line 776, ../../sass/_base.sass */
 .panel-title {
-  font-size: inherit;
-}
+  font-size: inherit; }
 
-/* line 780, ../../sass/_base.sass */
 .jumbotron {
   border-radius: 6px;
-  padding: 40px;
-}
+  padding: 40px; }
 
-/* line 785, ../../sass/_base.sass */
 .jumbotron h1 {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
 /* COLORS */
-/* line 791, ../../sass/_base.sass */
 .text-navy {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 795, ../../sass/_base.sass */
 .text-primary {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 799, ../../sass/_base.sass */
 .text-success {
-  color: #1c84c6;
-}
+  color: #1c84c6; }
 
-/* line 803, ../../sass/_base.sass */
 .text-info {
-  color: #23c6c8;
-}
+  color: #23c6c8; }
 
-/* line 807, ../../sass/_base.sass */
 .text-warning {
-  color: #f8ac59;
-}
+  color: #f8ac59; }
 
-/* line 811, ../../sass/_base.sass */
 .text-danger {
-  color: #ED5565;
-}
+  color: #ED5565; }
 
-/* line 815, ../../sass/_base.sass */
 .text-muted {
-  color: #888888;
-}
+  color: #888888; }
 
-/* line 819, ../../sass/_base.sass */
 .text-white {
-  color: #ffffff;
-}
+  color: #ffffff; }
 
-/* line 823, ../../sass/_base.sass */
 .simple_tag {
   background-color: #f3f3f4;
   border: 1px solid #e7eaec;
@@ -5401,18 +3700,14 @@ table.table-mail tr td {
   margin-right: 5px;
   margin-top: 5px;
   padding: 5px 12px;
-  display: inline-block;
-}
+  display: inline-block; }
 
-/* line 835, ../../sass/_base.sass */
 .img-shadow {
   -webkit-box-shadow: 0 0 3px 0 #919191;
   -moz-box-shadow: 0 0 3px 0 #919191;
-  box-shadow: 0 0 3px 0 #919191;
-}
+  box-shadow: 0 0 3px 0 #919191; }
 
 /* For handle diferent bg color in AngularJS version */
-/* line 842, ../../sass/_base.sass */
 .dashboards\.dashboard_2 nav.navbar,
 .dashboards\.dashboard_3 nav.navbar,
 .mailbox\.inbox nav.navbar,
@@ -5421,11 +3716,9 @@ table.table-mail tr td {
 .dashboards\.dashboard_4_1 nav.navbar,
 .metrics nav.navbar, .metrics\.index nav.navbar,
 .dashboards\.dashboard_5 nav.navbar {
-  background: #fff;
-}
+  background: #fff; }
 
 /* For handle diferent bg color in MVC version */
-/* line 854, ../../sass/_base.sass */
 .Dashboard_2 .navbar.navbar-static-top,
 .Dashboard_3 .navbar.navbar-static-top,
 .Dashboard_4_1 .navbar.navbar-static-top,
@@ -5434,587 +3727,365 @@ table.table-mail tr td {
 .Inbox .navbar.navbar-static-top,
 .Metrics .navbar.navbar-static-top,
 .Dashboard_5 .navbar.navbar-static-top {
-  background: #fff;
-}
+  background: #fff; }
 
-/* line 865, ../../sass/_base.sass */
 a.close-canvas-menu {
   position: absolute;
   top: 10px;
   right: 15px;
   z-index: 1011;
-  color: #a7b1c2;
-}
+  color: #a7b1c2; }
 
-/* line 873, ../../sass/_base.sass */
 a.close-canvas-menu:hover {
-  color: #fff;
-}
+  color: #fff; }
 
 /* FULL HEIGHT */
-/* line 879, ../../sass/_base.sass */
 .full-height {
-  height: 100%;
-}
+  height: 100%; }
 
-/* line 883, ../../sass/_base.sass */
 .fh-breadcrumb {
   height: calc(100% - 196px);
   margin: 0 -15px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 889, ../../sass/_base.sass */
 .fh-no-breadcrumb {
   height: calc(100% - 99px);
   margin: 0 -15px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 895, ../../sass/_base.sass */
 .fh-column {
   background: #fff;
   height: 100%;
   width: 240px;
-  float: left;
-}
+  float: left; }
 
-/* line 902, ../../sass/_base.sass */
 .modal-backdrop {
-  z-index: 2040 !important;
-}
+  z-index: 2040 !important; }
 
-/* line 906, ../../sass/_base.sass */
 .modal {
-  z-index: 2050 !important;
-}
+  z-index: 2050 !important; }
 
-/* line 910, ../../sass/_base.sass */
 .spiner-example {
   height: 200px;
-  padding-top: 70px;
-}
+  padding-top: 70px; }
 
 /* MARGINS & PADDINGS */
-/* line 917, ../../sass/_base.sass */
 .p-xxs {
-  padding: 5px;
-}
+  padding: 5px; }
 
-/* line 921, ../../sass/_base.sass */
 .p-xs {
-  padding: 10px;
-}
+  padding: 10px; }
 
-/* line 925, ../../sass/_base.sass */
 .p-sm {
-  padding: 15px;
-}
+  padding: 15px; }
 
-/* line 929, ../../sass/_base.sass */
 .p-m {
-  padding: 20px;
-}
+  padding: 20px; }
 
-/* line 933, ../../sass/_base.sass */
 .p-md {
-  padding: 25px;
-}
+  padding: 25px; }
 
-/* line 937, ../../sass/_base.sass */
 .p-lg {
-  padding: 30px;
-}
+  padding: 30px; }
 
-/* line 941, ../../sass/_base.sass */
 .p-xl {
-  padding: 40px;
-}
+  padding: 40px; }
 
-/* line 945, ../../sass/_base.sass */
 .p-w-xs {
-  padding: 0 10px;
-}
+  padding: 0 10px; }
 
-/* line 949, ../../sass/_base.sass */
 .p-w-sm {
-  padding: 0 15px;
-}
+  padding: 0 15px; }
 
-/* line 954, ../../sass/_base.sass */
 .p-w-m {
-  padding: 0 20px;
-}
+  padding: 0 20px; }
 
-/* line 959, ../../sass/_base.sass */
 .p-w-md {
-  padding: 0 25px;
-}
+  padding: 0 25px; }
 
-/* line 964, ../../sass/_base.sass */
 .p-w-lg {
-  padding: 0 30px;
-}
+  padding: 0 30px; }
 
-/* line 969, ../../sass/_base.sass */
 .p-w-xl {
-  padding: 0 40px;
-}
+  padding: 0 40px; }
 
-/* line 972, ../../sass/_base.sass */
 .p-h-xs {
-  padding: 10px 0;
-}
+  padding: 10px 0; }
 
-/* line 976, ../../sass/_base.sass */
 .p-h-sm {
-  padding: 15px 0;
-}
+  padding: 15px 0; }
 
-/* line 979, ../../sass/_base.sass */
 .p-h-m {
-  padding: 20px 0;
-}
+  padding: 20px 0; }
 
-/* line 982, ../../sass/_base.sass */
 .p-h-md {
-  padding: 25px 0;
-}
+  padding: 25px 0; }
 
-/* line 985, ../../sass/_base.sass */
 .p-h-lg {
-  padding: 30px 0;
-}
+  padding: 30px 0; }
 
-/* line 988, ../../sass/_base.sass */
 .p-h-xl {
-  padding: 40px 0;
-}
+  padding: 40px 0; }
 
-/* line 992, ../../sass/_base.sass */
 .m-xxs {
-  margin: 2px 4px;
-}
+  margin: 2px 4px; }
 
-/* line 996, ../../sass/_base.sass */
 .m-xs {
-  margin: 5px;
-}
+  margin: 5px; }
 
-/* line 1000, ../../sass/_base.sass */
 .m-sm {
-  margin: 10px;
-}
+  margin: 10px; }
 
-/* line 1004, ../../sass/_base.sass */
 .m {
-  margin: 15px;
-}
+  margin: 15px; }
 
-/* line 1008, ../../sass/_base.sass */
 .m-md {
-  margin: 20px;
-}
+  margin: 20px; }
 
-/* line 1012, ../../sass/_base.sass */
 .m-lg {
-  margin: 30px;
-}
+  margin: 30px; }
 
-/* line 1016, ../../sass/_base.sass */
 .m-xl {
-  margin: 50px;
-}
+  margin: 50px; }
 
-/* line 1020, ../../sass/_base.sass */
 .m-n {
-  margin: 0 !important;
-}
+  margin: 0 !important; }
 
-/* line 1024, ../../sass/_base.sass */
 .m-l-none {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
-/* line 1028, ../../sass/_base.sass */
 .m-l-xs {
-  margin-left: 5px;
-}
+  margin-left: 5px; }
 
-/* line 1032, ../../sass/_base.sass */
 .m-l-sm {
-  margin-left: 10px;
-}
+  margin-left: 10px; }
 
-/* line 1036, ../../sass/_base.sass */
 .m-l {
-  margin-left: 15px;
-}
+  margin-left: 15px; }
 
-/* line 1040, ../../sass/_base.sass */
 .m-l-md {
-  margin-left: 20px;
-}
+  margin-left: 20px; }
 
-/* line 1044, ../../sass/_base.sass */
 .m-l-lg {
-  margin-left: 30px;
-}
+  margin-left: 30px; }
 
-/* line 1048, ../../sass/_base.sass */
 .m-l-xl {
-  margin-left: 40px;
-}
+  margin-left: 40px; }
 
-/* line 1052, ../../sass/_base.sass */
 .m-l-n-xxs {
-  margin-left: -1px;
-}
+  margin-left: -1px; }
 
-/* line 1056, ../../sass/_base.sass */
 .m-l-n-xs {
-  margin-left: -5px;
-}
+  margin-left: -5px; }
 
-/* line 1060, ../../sass/_base.sass */
 .m-l-n-sm {
-  margin-left: -10px;
-}
+  margin-left: -10px; }
 
-/* line 1064, ../../sass/_base.sass */
 .m-l-n {
-  margin-left: -15px;
-}
+  margin-left: -15px; }
 
-/* line 1068, ../../sass/_base.sass */
 .m-l-n-md {
-  margin-left: -20px;
-}
+  margin-left: -20px; }
 
-/* line 1072, ../../sass/_base.sass */
 .m-l-n-lg {
-  margin-left: -30px;
-}
+  margin-left: -30px; }
 
-/* line 1076, ../../sass/_base.sass */
 .m-l-n-xl {
-  margin-left: -40px;
-}
+  margin-left: -40px; }
 
-/* line 1080, ../../sass/_base.sass */
 .m-t-none {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 1084, ../../sass/_base.sass */
 .m-t-xxs {
-  margin-top: 1px;
-}
+  margin-top: 1px; }
 
-/* line 1088, ../../sass/_base.sass */
 .m-t-xs {
-  margin-top: 5px;
-}
+  margin-top: 5px; }
 
-/* line 1092, ../../sass/_base.sass */
 .m-t-sm {
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 1096, ../../sass/_base.sass */
 .m-t {
-  margin-top: 15px;
-}
+  margin-top: 15px; }
 
-/* line 1100, ../../sass/_base.sass */
 .m-t-md {
-  margin-top: 20px;
-}
+  margin-top: 20px; }
 
-/* line 1104, ../../sass/_base.sass */
 .m-t-lg {
-  margin-top: 30px;
-}
+  margin-top: 30px; }
 
-/* line 1108, ../../sass/_base.sass */
 .m-t-xl {
-  margin-top: 40px;
-}
+  margin-top: 40px; }
 
-/* line 1112, ../../sass/_base.sass */
 .m-t-n-xxs {
-  margin-top: -1px;
-}
+  margin-top: -1px; }
 
-/* line 1116, ../../sass/_base.sass */
 .m-t-n-xs {
-  margin-top: -5px;
-}
+  margin-top: -5px; }
 
-/* line 1120, ../../sass/_base.sass */
 .m-t-n-sm {
-  margin-top: -10px;
-}
+  margin-top: -10px; }
 
-/* line 1124, ../../sass/_base.sass */
 .m-t-n {
-  margin-top: -15px;
-}
+  margin-top: -15px; }
 
-/* line 1128, ../../sass/_base.sass */
 .m-t-n-md {
-  margin-top: -20px;
-}
+  margin-top: -20px; }
 
-/* line 1132, ../../sass/_base.sass */
 .m-t-n-lg {
-  margin-top: -30px;
-}
+  margin-top: -30px; }
 
-/* line 1136, ../../sass/_base.sass */
 .m-t-n-xl {
-  margin-top: -40px;
-}
+  margin-top: -40px; }
 
-/* line 1140, ../../sass/_base.sass */
 .m-r-none {
-  margin-right: 0;
-}
+  margin-right: 0; }
 
-/* line 1144, ../../sass/_base.sass */
 .m-r-xxs {
-  margin-right: 1px;
-}
+  margin-right: 1px; }
 
-/* line 1147, ../../sass/_base.sass */
 .m {
-  margin: 15px;
-}
+  margin: 15px; }
 
-/* line 1151, ../../sass/_base.sass */
 .m-r-xs {
-  margin-right: 5px;
-}
+  margin-right: 5px; }
 
-/* line 1155, ../../sass/_base.sass */
 .m-r-sm {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 1159, ../../sass/_base.sass */
 .m-r {
-  margin-right: 15px;
-}
+  margin-right: 15px; }
 
-/* line 1163, ../../sass/_base.sass */
 .m-r-md {
-  margin-right: 20px;
-}
+  margin-right: 20px; }
 
-/* line 1167, ../../sass/_base.sass */
 .m-r-lg {
-  margin-right: 30px;
-}
+  margin-right: 30px; }
 
-/* line 1171, ../../sass/_base.sass */
 .m-r-xl {
-  margin-right: 40px;
-}
+  margin-right: 40px; }
 
-/* line 1175, ../../sass/_base.sass */
 .m-r-n-xxs {
-  margin-right: -1px;
-}
+  margin-right: -1px; }
 
-/* line 1179, ../../sass/_base.sass */
 .m-r-n-xs {
-  margin-right: -5px;
-}
+  margin-right: -5px; }
 
-/* line 1183, ../../sass/_base.sass */
 .m-r-n-sm {
-  margin-right: -10px;
-}
+  margin-right: -10px; }
 
-/* line 1187, ../../sass/_base.sass */
 .m-r-n {
-  margin-right: -15px;
-}
+  margin-right: -15px; }
 
-/* line 1191, ../../sass/_base.sass */
 .m-r-n-md {
-  margin-right: -20px;
-}
+  margin-right: -20px; }
 
-/* line 1195, ../../sass/_base.sass */
 .m-r-n-lg {
-  margin-right: -30px;
-}
+  margin-right: -30px; }
 
-/* line 1199, ../../sass/_base.sass */
 .m-r-n-xl {
-  margin-right: -40px;
-}
+  margin-right: -40px; }
 
-/* line 1203, ../../sass/_base.sass */
 .m-b-none {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 1207, ../../sass/_base.sass */
 .m-b-xxs {
-  margin-bottom: 1px;
-}
+  margin-bottom: 1px; }
 
-/* line 1211, ../../sass/_base.sass */
 .m-b-xs {
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
-/* line 1215, ../../sass/_base.sass */
 .m-b-sm {
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 1219, ../../sass/_base.sass */
 .m-b {
-  margin-bottom: 15px;
-}
+  margin-bottom: 15px; }
 
-/* line 1223, ../../sass/_base.sass */
 .m-b-md {
-  margin-bottom: 20px;
-}
+  margin-bottom: 20px; }
 
-/* line 1227, ../../sass/_base.sass */
 .m-b-lg {
-  margin-bottom: 30px;
-}
+  margin-bottom: 30px; }
 
-/* line 1231, ../../sass/_base.sass */
 .m-b-xl {
-  margin-bottom: 40px;
-}
+  margin-bottom: 40px; }
 
-/* line 1235, ../../sass/_base.sass */
 .m-b-n-xxs {
-  margin-bottom: -1px;
-}
+  margin-bottom: -1px; }
 
-/* line 1239, ../../sass/_base.sass */
 .m-b-n-xs {
-  margin-bottom: -5px;
-}
+  margin-bottom: -5px; }
 
-/* line 1243, ../../sass/_base.sass */
 .m-b-n-sm {
-  margin-bottom: -10px;
-}
+  margin-bottom: -10px; }
 
-/* line 1247, ../../sass/_base.sass */
 .m-b-n {
-  margin-bottom: -15px;
-}
+  margin-bottom: -15px; }
 
-/* line 1251, ../../sass/_base.sass */
 .m-b-n-md {
-  margin-bottom: -20px;
-}
+  margin-bottom: -20px; }
 
-/* line 1255, ../../sass/_base.sass */
 .m-b-n-lg {
-  margin-bottom: -30px;
-}
+  margin-bottom: -30px; }
 
-/* line 1259, ../../sass/_base.sass */
 .m-b-n-xl {
-  margin-bottom: -40px;
-}
+  margin-bottom: -40px; }
 
-/* line 1263, ../../sass/_base.sass */
 .space-15 {
-  margin: 15px 0;
-}
+  margin: 15px 0; }
 
-/* line 1267, ../../sass/_base.sass */
 .space-20 {
-  margin: 20px 0;
-}
+  margin: 20px 0; }
 
-/* line 1271, ../../sass/_base.sass */
 .space-25 {
-  margin: 25px 0;
-}
+  margin: 25px 0; }
 
-/* line 1275, ../../sass/_base.sass */
 .space-30 {
-  margin: 30px 0;
-}
+  margin: 30px 0; }
 
-/* line 1278, ../../sass/_base.sass */
 .img-sm {
   width: 32px;
-  height: 32px;
-}
+  height: 32px; }
 
-/* line 1283, ../../sass/_base.sass */
 .img-md {
   width: 64px;
-  height: 64px;
-}
+  height: 64px; }
 
-/* line 1288, ../../sass/_base.sass */
 .img-lg {
   width: 96px;
-  height: 96px;
-}
+  height: 96px; }
 
-/* line 1294, ../../sass/_base.sass */
 .b-r-xs {
   -webkit-border-radius: 1px;
   -moz-border-radius: 1px;
-  border-radius: 1px;
-}
+  border-radius: 1px; }
 
-/* line 1300, ../../sass/_base.sass */
 .b-r-sm {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
-/* line 1306, ../../sass/_base.sass */
 .b-r-md {
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
-  border-radius: 6px;
-}
+  border-radius: 6px; }
 
-/* line 1312, ../../sass/_base.sass */
 .b-r-lg {
   -webkit-border-radius: 12px;
   -moz-border-radius: 12px;
-  border-radius: 12px;
-}
+  border-radius: 12px; }
 
-/* line 1318, ../../sass/_base.sass */
 .b-r-xl {
   -webkit-border-radius: 24px;
   -moz-border-radius: 24px;
-  border-radius: 24px;
-}
+  border-radius: 24px; }
 
-/* line 1327, ../../sass/_base.sass */
 .fullscreen-ibox-mode .animated {
-  animation: none;
-}
+  animation: none; }
 
-/* line 1331, ../../sass/_base.sass */
 body.fullscreen-ibox-mode {
-  overflow-y: hidden;
-}
+  overflow-y: hidden; }
 
-/* line 1335, ../../sass/_base.sass */
 .ibox.fullscreen {
   z-index: 2030;
   position: fixed;
@@ -6023,276 +4094,190 @@ body.fullscreen-ibox-mode {
   right: 0;
   bottom: 0;
   overflow: auto;
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 1346, ../../sass/_base.sass */
 .ibox.fullscreen .collapse-link {
-  display: none;
-}
+  display: none; }
 
-/* line 1350, ../../sass/_base.sass */
 .ibox.fullscreen .ibox-content {
-  min-height: calc(100% - 48px);
-}
+  min-height: calc(100% - 48px); }
 
-/* line 1356, ../../sass/_base.sass */
 body.modal-open {
-  padding-right: inherit !important;
-}
+  padding-right: inherit !important; }
 
-/* line 1360, ../../sass/_base.sass */
 body.modal-open .wrapper-content.animated {
-  -webkit-animation: none;
-}
+  -webkit-animation: none; }
 
-/* line 1364, ../../sass/_base.sass */
 body.modal-open .animated {
   animation-fill-mode: initial;
   -ms-animation-nam: none;
-  z-index: inherit;
-}
+  z-index: inherit; }
 
 /* Show profile dropdown on fixed sidebar */
-/* line 1371, ../../sass/_base.sass */
 body.mini-navbar.fixed-sidebar .profile-element, .block {
-  display: block !important;
-}
+  display: block !important; }
 
-/* line 1375, ../../sass/_base.sass */
 body.mini-navbar.fixed-sidebar .nav-header {
-  padding: 33px 25px;
-}
+  padding: 33px 25px; }
 
-/* line 1379, ../../sass/_base.sass */
 body.mini-navbar.fixed-sidebar .logo-element {
-  display: none;
-}
+  display: none; }
 
-/* line 1385, ../../sass/_base.sass */
 .fullscreen-video .animated {
-  animation: none;
-}
+  animation: none; }
 
 /* SEARCH PAGE */
-/* line 3, ../../sass/_pages.sass */
 .search-form {
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 7, ../../sass/_pages.sass */
+.search-result .created-at {
+  white-space: nowrap; }
+
 .search-result h3 {
-  margin-bottom: 0;
-  color: #1E0FBE;
-}
+  margin: 0 0 2px 0; }
 
-/* line 12, ../../sass/_pages.sass */
 .search-result .search-link {
-  color: #006621;
-}
+  color: #006621; }
 
-/* line 16, ../../sass/_pages.sass */
 .search-result p {
   font-size: 12px;
-  margin-top: 5px;
-}
+  margin-top: 3px; }
 
 /* CONTACTS */
-/* line 23, ../../sass/_pages.sass */
 .contact-box {
   background-color: #ffffff;
   border: 1px solid #e7eaec;
   padding: 20px;
-  margin-bottom: 20px;
-}
+  margin-bottom: 20px; }
 
-/* line 30, ../../sass/_pages.sass */
 .contact-box > a {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 34, ../../sass/_pages.sass */
 .contact-box.center-version {
   border: 1px solid #e7eaec;
-  padding: 0;
-}
+  padding: 0; }
 
-/* line 40, ../../sass/_pages.sass */
 .contact-box.center-version > a {
   display: block;
   background-color: #ffffff;
   padding: 20px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 47, ../../sass/_pages.sass */
 .contact-box.center-version > a img {
   width: 80px;
   height: 80px;
   margin-top: 10px;
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 54, ../../sass/_pages.sass */
 .contact-box.center-version address {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 58, ../../sass/_pages.sass */
 .contact-box .contact-box-footer {
   text-align: center;
   background-color: #ffffff;
   border-top: 1px solid #e7eaec;
-  padding: 15px 20px;
-}
+  padding: 15px 20px; }
 
 /* INVOICE */
-/* line 67, ../../sass/_pages.sass */
 .invoice-table tbody > tr > td:last-child, .invoice-table tbody > tr > td:nth-child(4), .invoice-table tbody > tr > td:nth-child(3), .invoice-table tbody > tr > td:nth-child(2) {
-  text-align: right;
-}
+  text-align: right; }
 
-/* line 71, ../../sass/_pages.sass */
 .invoice-table thead > tr > th:last-child, .invoice-table thead > tr > th:nth-child(4), .invoice-table thead > tr > th:nth-child(3), .invoice-table thead > tr > th:nth-child(2) {
-  text-align: right;
-}
+  text-align: right; }
 
-/* line 75, ../../sass/_pages.sass */
 .invoice-total > tbody > tr > td:first-child {
-  text-align: right;
-}
+  text-align: right; }
 
-/* line 79, ../../sass/_pages.sass */
 .invoice-total > tbody > tr > td {
-  border: 0 none;
-}
+  border: 0 none; }
 
-/* line 83, ../../sass/_pages.sass */
 .invoice-total > tbody > tr > td:last-child {
   border-bottom: 1px solid #DDDDDD;
   text-align: right;
-  width: 15%;
-}
+  width: 15%; }
 
 /* ERROR & LOGIN & LOCKSCREEN */
-/* line 91, ../../sass/_pages.sass */
 .middle-box {
   max-width: 400px;
   z-index: 100;
   margin: 0 auto;
-  padding-top: 40px;
-}
+  padding-top: 40px; }
 
-/* line 98, ../../sass/_pages.sass */
 .lockscreen.middle-box {
   width: 200px;
-  padding-top: 110px;
-}
+  padding-top: 110px; }
 
-/* line 103, ../../sass/_pages.sass */
 .loginscreen.middle-box {
-  width: 300px;
-}
+  width: 300px; }
 
-/* line 107, ../../sass/_pages.sass */
 .loginColumns {
   max-width: 800px;
   margin: 0 auto;
-  padding: 100px 20px 20px 20px;
-}
+  padding: 100px 20px 20px 20px; }
 
-/* line 113, ../../sass/_pages.sass */
 .passwordBox {
   max-width: 460px;
   margin: 0 auto;
-  padding: 100px 20px 20px 20px;
-}
+  padding: 100px 20px 20px 20px; }
 
-/* line 119, ../../sass/_pages.sass */
 .logo-name {
   color: #e6e6e6;
   font-size: 180px;
   font-weight: 800;
   letter-spacing: -10px;
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
-/* line 127, ../../sass/_pages.sass */
 .middle-box h1 {
-  font-size: 170px;
-}
+  font-size: 170px; }
 
-/* line 131, ../../sass/_pages.sass */
 .wrapper .middle-box {
-  margin-top: 140px;
-}
+  margin-top: 140px; }
 
-/* line 135, ../../sass/_pages.sass */
 .lock-word {
   z-index: 10;
   position: absolute;
   top: 110px;
   left: 50%;
-  margin-left: -470px;
-}
+  margin-left: -470px; }
 
-/* line 143, ../../sass/_pages.sass */
 .lock-word span {
   font-size: 100px;
   font-weight: 600;
   color: #e9e9e9;
-  display: inline-block;
-}
+  display: inline-block; }
 
-/* line 150, ../../sass/_pages.sass */
 .lock-word .first-word {
-  margin-right: 160px;
-}
+  margin-right: 160px; }
 
 /* DASBOARD */
-/* line 156, ../../sass/_pages.sass */
 .dashboard-header {
   border-top: 0;
-  padding: 20px 20px 20px 20px;
-}
+  padding: 20px 20px 20px 20px; }
 
-/* line 161, ../../sass/_pages.sass */
 .dashboard-header h2 {
   margin-top: 10px;
-  font-size: 26px;
-}
+  font-size: 26px; }
 
-/* line 166, ../../sass/_pages.sass */
 .fist-item {
-  border-top: none !important;
-}
+  border-top: none !important; }
 
-/* line 170, ../../sass/_pages.sass */
 .statistic-box {
-  margin-top: 40px;
-}
+  margin-top: 40px; }
 
-/* line 175, ../../sass/_pages.sass */
 .dashboard-header .list-group-item span.label {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 179, ../../sass/_pages.sass */
 .list-group.clear-list .list-group-item {
   border-top: 1px solid #e7eaec;
   border-bottom: 0;
   border-right: 0;
   border-left: 0;
-  padding: 10px 0;
-}
+  padding: 10px 0; }
 
-/* line 187, ../../sass/_pages.sass */
 ul.clear-list:first-child {
-  border-top: none !important;
-}
+  border-top: none !important; }
 
 /* Intimeline */
-/* line 193, ../../sass/_pages.sass */
 .timeline-item .date i {
   position: absolute;
   top: 0;
@@ -6303,43 +4288,31 @@ ul.clear-list:first-child {
   border-top: 1px solid #e7eaec;
   border-bottom: 1px solid #e7eaec;
   border-left: 1px solid #e7eaec;
-  background: #f8f8f8;
-}
+  background: #f8f8f8; }
 
-/* line 206, ../../sass/_pages.sass */
 .timeline-item .date {
   text-align: right;
   width: 110px;
   position: relative;
-  padding-top: 30px;
-}
+  padding-top: 30px; }
 
-/* line 213, ../../sass/_pages.sass */
 .timeline-item .content {
   border-left: 1px solid #e7eaec;
   border-top: 1px solid #e7eaec;
   padding-top: 10px;
-  min-height: 100px;
-}
+  min-height: 100px; }
 
-/* line 220, ../../sass/_pages.sass */
 .timeline-item .content:hover {
-  background: #f6f6f6;
-}
+  background: #f6f6f6; }
 
 /* PIN BOARD */
-/* line 225, ../../sass/_pages.sass */
 ul.notes li, ul.tag-list li {
-  list-style: none;
-}
+  list-style: none; }
 
-/* line 229, ../../sass/_pages.sass */
 ul.notes li h4 {
   margin-top: 20px;
-  font-size: 16px;
-}
+  font-size: 16px; }
 
-/* line 234, ../../sass/_pages.sass */
 ul.notes li div {
   text-decoration: none;
   color: #000;
@@ -6348,37 +4321,27 @@ ul.notes li div {
   height: 140px;
   width: 140px;
   padding: 1em;
-  position: relative;
-}
+  position: relative; }
 
-/* line 245, ../../sass/_pages.sass */
 ul.notes li div small {
   position: absolute;
   top: 5px;
   right: 5px;
-  font-size: 10px;
-}
+  font-size: 10px; }
 
-/* line 252, ../../sass/_pages.sass */
 ul.notes li div a {
   position: absolute;
   right: 10px;
   bottom: 10px;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 259, ../../sass/_pages.sass */
 ul.notes li {
   margin: 10px 40px 50px 0;
-  float: left;
-}
+  float: left; }
 
-/* line 264, ../../sass/_pages.sass */
 ul.notes li div p {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 268, ../../sass/_pages.sass */
 ul.notes li div {
   text-decoration: none;
   color: #000;
@@ -6392,58 +4355,46 @@ ul.notes li div {
   /* Safari+Chrome */
   -webkit-box-shadow: 5px 5px 2px rgba(33, 33, 33, 0.7);
   /* Opera */
-  box-shadow: 5px 5px 2px rgba(33, 33, 33, 0.7);
-}
+  box-shadow: 5px 5px 2px rgba(33, 33, 33, 0.7); }
 
-/* line 284, ../../sass/_pages.sass */
 ul.notes li div {
   -webkit-transform: rotate(-6deg);
   -o-transform: rotate(-6deg);
   -moz-transform: rotate(-6deg);
-  -ms-transform: rotate(-6deg);
-}
+  -ms-transform: rotate(-6deg); }
 
-/* line 291, ../../sass/_pages.sass */
 ul.notes li:nth-child(even) div {
   -o-transform: rotate(4deg);
   -webkit-transform: rotate(4deg);
   -moz-transform: rotate(4deg);
   -ms-transform: rotate(4deg);
   position: relative;
-  top: 5px;
-}
+  top: 5px; }
 
-/* line 300, ../../sass/_pages.sass */
 ul.notes li:nth-child(3n) div {
   -o-transform: rotate(-3deg);
   -webkit-transform: rotate(-3deg);
   -moz-transform: rotate(-3deg);
   -ms-transform: rotate(-3deg);
   position: relative;
-  top: -5px;
-}
+  top: -5px; }
 
-/* line 309, ../../sass/_pages.sass */
 ul.notes li:nth-child(5n) div {
   -o-transform: rotate(5deg);
   -webkit-transform: rotate(5deg);
   -moz-transform: rotate(5deg);
   -ms-transform: rotate(5deg);
   position: relative;
-  top: -10px;
-}
+  top: -10px; }
 
-/* line 318, ../../sass/_pages.sass */
 ul.notes li div:hover, ul.notes li div:focus {
   -webkit-transform: scale(1.1);
   -moz-transform: scale(1.1);
   -o-transform: scale(1.1);
   -ms-transform: scale(1.1);
   position: relative;
-  z-index: 5;
-}
+  z-index: 5; }
 
-/* line 328, ../../sass/_pages.sass */
 ul.notes li div {
   text-decoration: none;
   color: #000;
@@ -6457,101 +4408,67 @@ ul.notes li div {
   box-shadow: 5px 5px 7px rgba(33, 33, 33, 0.7);
   -moz-transition: -moz-transform 0.15s linear;
   -o-transition: -o-transform 0.15s linear;
-  -webkit-transition: -webkit-transform 0.15s linear;
-}
+  -webkit-transition: -webkit-transform 0.15s linear; }
 
 /* FILE MANAGER */
-/* line 346, ../../sass/_pages.sass */
 .file-box {
   float: left;
-  width: 220px;
-}
+  width: 220px; }
 
-/* line 351, ../../sass/_pages.sass */
 .file-manager h5 {
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
-/* line 355, ../../sass/_pages.sass */
 .file-manager {
   list-style: none outside none;
   margin: 0;
-  padding: 0;
-}
+  padding: 0; }
 
-/* line 361, ../../sass/_pages.sass */
 .folder-list li a {
   color: #666666;
   display: block;
-  padding: 5px 0;
-}
+  padding: 5px 0; }
 
-/* line 367, ../../sass/_pages.sass */
 .folder-list li {
   border-bottom: 1px solid #e7eaec;
-  display: block;
-}
+  display: block; }
 
-/* line 372, ../../sass/_pages.sass */
 .folder-list li i {
   margin-right: 8px;
-  color: #3d4d5d;
-}
+  color: #3d4d5d; }
 
-/* line 377, ../../sass/_pages.sass */
 .category-list li a {
   color: #666666;
   display: block;
-  padding: 5px 0;
-}
+  padding: 5px 0; }
 
-/* line 383, ../../sass/_pages.sass */
 .category-list li {
-  display: block;
-}
+  display: block; }
 
-/* line 387, ../../sass/_pages.sass */
 .category-list li i {
   margin-right: 8px;
-  color: #3d4d5d;
-}
+  color: #3d4d5d; }
 
-/* line 392, ../../sass/_pages.sass */
 .category-list li a .text-navy {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 396, ../../sass/_pages.sass */
 .category-list li a .text-primary {
-  color: #1c84c6;
-}
+  color: #1c84c6; }
 
-/* line 400, ../../sass/_pages.sass */
 .category-list li a .text-info {
-  color: #23c6c8;
-}
+  color: #23c6c8; }
 
-/* line 404, ../../sass/_pages.sass */
 .category-list li a .text-danger {
-  color: #EF5352;
-}
+  color: #EF5352; }
 
-/* line 408, ../../sass/_pages.sass */
 .category-list li a .text-warning {
-  color: #F8AC59;
-}
+  color: #F8AC59; }
 
-/* line 412, ../../sass/_pages.sass */
 .file-manager h5.tag-title {
-  margin-top: 20px;
-}
+  margin-top: 20px; }
 
-/* line 416, ../../sass/_pages.sass */
 .tag-list li {
-  float: left;
-}
+  float: left; }
 
-/* line 420, ../../sass/_pages.sass */
 .tag-list li a {
   font-size: 10px;
   background-color: #f3f3f4;
@@ -6561,67 +4478,47 @@ ul.notes li div {
   border: 1px solid #e7eaec;
   margin-right: 5px;
   margin-top: 5px;
-  display: block;
-}
+  display: block; }
 
-/* line 432, ../../sass/_pages.sass */
 .file {
   border: 1px solid #e7eaec;
   padding: 0;
   background-color: #ffffff;
   position: relative;
   margin-bottom: 20px;
-  margin-right: 20px;
-}
+  margin-right: 20px; }
 
-/* line 441, ../../sass/_pages.sass */
 .file-manager .hr-line-dashed {
-  margin: 15px 0;
-}
+  margin: 15px 0; }
 
-/* line 445, ../../sass/_pages.sass */
 .file .icon, .file .image {
   height: 100px;
-  overflow: hidden;
-}
+  overflow: hidden; }
 
-/* line 450, ../../sass/_pages.sass */
 .file .icon {
   padding: 15px 10px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 455, ../../sass/_pages.sass */
 .file-control {
   color: inherit;
   font-size: 11px;
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 461, ../../sass/_pages.sass */
 .file-control.active {
-  text-decoration: underline;
-}
+  text-decoration: underline; }
 
-/* line 465, ../../sass/_pages.sass */
 .file .icon i {
   font-size: 70px;
-  color: #dadada;
-}
+  color: #dadada; }
 
-/* line 470, ../../sass/_pages.sass */
 .file .file-name {
   padding: 10px;
   background-color: #f8f8f8;
-  border-top: 1px solid #e7eaec;
-}
+  border-top: 1px solid #e7eaec; }
 
-/* line 476, ../../sass/_pages.sass */
 .file-name small {
-  color: #676a6c;
-}
+  color: #676a6c; }
 
-/* line 480, ../../sass/_pages.sass */
 .corner {
   position: absolute;
   display: inline-block;
@@ -6632,84 +4529,54 @@ ul.notes li div {
   border-right: 0.6em solid #f1f1f1;
   border-bottom: 0.6em solid #f1f1f1;
   right: 0em;
-  bottom: 0em;
-}
+  bottom: 0em; }
 
-/* line 493, ../../sass/_pages.sass */
 a.compose-mail {
-  padding: 8px 10px;
-}
+  padding: 8px 10px; }
 
-/* line 497, ../../sass/_pages.sass */
 .mail-search {
-  max-width: 300px;
-}
+  max-width: 300px; }
 
 /* PROFILE */
-/* line 503, ../../sass/_pages.sass */
 .profile-content {
-  border-top: none !important;
-}
+  border-top: none !important; }
 
-/* line 507, ../../sass/_pages.sass */
 .profile-stats {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 511, ../../sass/_pages.sass */
 .profile-image {
   width: 120px;
-  float: left;
-}
+  float: left; }
 
-/* line 516, ../../sass/_pages.sass */
 .profile-image img {
   width: 96px;
-  height: 96px;
-}
+  height: 96px; }
 
-/* line 521, ../../sass/_pages.sass */
 .profile-info {
-  margin-left: 120px;
-}
+  margin-left: 120px; }
 
-/* line 525, ../../sass/_pages.sass */
 .feed-activity-list .feed-element {
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 529, ../../sass/_pages.sass */
 .feed-element:first-child {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 533, ../../sass/_pages.sass */
 .feed-element {
-  padding-bottom: 15px;
-}
+  padding-bottom: 15px; }
 
-/* line 537, ../../sass/_pages.sass */
 .feed-element, .feed-element .media {
-  margin-top: 15px;
-}
+  margin-top: 15px; }
 
-/* line 541, ../../sass/_pages.sass */
 .feed-element, .media-body {
-  overflow: hidden;
-}
+  overflow: hidden; }
 
-/* line 545, ../../sass/_pages.sass */
 .feed-element > .pull-left {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 549, ../../sass/_pages.sass */
 .feed-element img.img-circle, .dropdown-messages-box img.img-circle {
   width: 38px;
-  height: 38px;
-}
+  height: 38px; }
 
-/* line 554, ../../sass/_pages.sass */
 .feed-element .well {
   border: 1px solid #e7eaec;
   box-shadow: none;
@@ -6717,163 +4584,113 @@ a.compose-mail {
   margin-bottom: 5px;
   padding: 10px 20px;
   font-size: 11px;
-  line-height: 16px;
-}
+  line-height: 16px; }
 
-/* line 564, ../../sass/_pages.sass */
 .feed-element .actions {
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 568, ../../sass/_pages.sass */
 .feed-element .photos {
-  margin: 10px 0;
-}
+  margin: 10px 0; }
 
-/* line 573, ../../sass/_pages.sass */
 .feed-photo {
   max-height: 180px;
   border-radius: 4px;
   overflow: hidden;
   margin-right: 10px;
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 581, ../../sass/_pages.sass */
 .file-list li {
   padding: 5px 10px;
   font-size: 11px;
   border-radius: 2px;
   border: 1px solid #e7eaec;
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
-/* line 590, ../../sass/_pages.sass */
 .file-list li a {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 594, ../../sass/_pages.sass */
 .file-list li a:hover {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 598, ../../sass/_pages.sass */
 .user-friends img {
   width: 42px;
   height: 42px;
   margin-bottom: 5px;
-  margin-right: 5px;
-}
+  margin-right: 5px; }
 
 /* MAILBOX */
-/* line 608, ../../sass/_pages.sass */
 .mail-box {
   background-color: #ffffff;
   border: 1px solid #e7eaec;
   border-top: 0;
   padding: 0;
-  margin-bottom: 20px;
-}
+  margin-bottom: 20px; }
 
-/* line 616, ../../sass/_pages.sass */
 .mail-box-header {
   background-color: #ffffff;
   border: 1px solid #e7eaec;
   border-bottom: 0;
-  padding: 30px 20px 20px 20px;
-}
+  padding: 30px 20px 20px 20px; }
 
-/* line 623, ../../sass/_pages.sass */
 .mail-box-header h2 {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 627, ../../sass/_pages.sass */
 .mailbox-content .tag-list li a {
-  background: #ffffff;
-}
+  background: #ffffff; }
 
-/* line 631, ../../sass/_pages.sass */
 .mail-body {
   border-top: 1px solid #e7eaec;
-  padding: 20px;
-}
+  padding: 20px; }
 
-/* line 636, ../../sass/_pages.sass */
 .mail-text {
-  border-top: 1px solid #e7eaec;
-}
+  border-top: 1px solid #e7eaec; }
 
-/* line 640, ../../sass/_pages.sass */
 .mail-text .note-toolbar {
-  padding: 10px 15px;
-}
+  padding: 10px 15px; }
 
-/* line 644, ../../sass/_pages.sass */
 .mail-body .form-group {
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
-/* line 648, ../../sass/_pages.sass */
 .mail-text .note-editor .note-toolbar {
-  background-color: #F9F8F8;
-}
+  background-color: #F9F8F8; }
 
-/* line 652, ../../sass/_pages.sass */
 .mail-attachment {
   border-top: 1px solid #e7eaec;
   padding: 20px;
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 658, ../../sass/_pages.sass */
 .mailbox-content {
   background: none;
   border: none;
-  padding: 10px;
-}
+  padding: 10px; }
 
-/* line 664, ../../sass/_pages.sass */
 .mail-ontact {
-  width: 23%;
-}
+  width: 23%; }
 
 /* PROJECTS */
-/* line 669, ../../sass/_pages.sass */
 .project-people, .project-actions {
   text-align: right;
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
-/* line 674, ../../sass/_pages.sass */
 dd.project-people {
   text-align: left;
-  margin-top: 5px;
-}
+  margin-top: 5px; }
 
-/* line 679, ../../sass/_pages.sass */
 .project-people img {
   width: 32px;
-  height: 32px;
-}
+  height: 32px; }
 
-/* line 684, ../../sass/_pages.sass */
 .project-title a {
   font-size: 14px;
   color: #676a6c;
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 690, ../../sass/_pages.sass */
 .project-list table tr td {
   border-top: none;
   border-bottom: 1px solid #e7eaec;
   padding: 15px 10px;
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
-/* line 697, ../../sass/_pages.sass */
 .project-manager .tag-list li a {
   font-size: 10px;
   background-color: white;
@@ -6883,133 +4700,92 @@ dd.project-people {
   border: 1px solid #e7eaec;
   margin-right: 5px;
   margin-top: 5px;
-  display: block;
-}
+  display: block; }
 
-/* line 709, ../../sass/_pages.sass */
 .project-files li a {
   font-size: 11px;
   color: #676a6c;
   margin-left: 10px;
-  line-height: 22px;
-}
+  line-height: 22px; }
 
 /* FAQ */
-/* line 718, ../../sass/_pages.sass */
 .faq-item {
   padding: 20px;
   margin-bottom: 2px;
-  background: #fff;
-}
+  background: #fff; }
 
-/* line 724, ../../sass/_pages.sass */
 .faq-question {
   font-size: 18px;
   font-weight: 600;
   color: #1ab394;
-  display: block;
-}
+  display: block; }
 
-/* line 731, ../../sass/_pages.sass */
 .faq-question:hover {
-  color: #179d82;
-}
+  color: #179d82; }
 
-/* line 735, ../../sass/_pages.sass */
 .faq-answer {
   margin-top: 10px;
   background: #f3f3f4;
   border: 1px solid #e7eaec;
   border-radius: 3px;
-  padding: 15px;
-}
+  padding: 15px; }
 
-/* line 743, ../../sass/_pages.sass */
 .faq-item .tag-item {
   background: #f3f3f4;
   padding: 2px 6px;
   font-size: 10px;
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
 /* Chat view */
-/* line 751, ../../sass/_pages.sass */
 .message-input {
-  height: 90px !important;
-}
+  height: 90px !important; }
 
-/* line 755, ../../sass/_pages.sass */
 .chat-avatar {
   width: 36px;
   height: 36px;
   float: left;
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 762, ../../sass/_pages.sass */
 .chat-user-name {
-  padding: 10px;
-}
+  padding: 10px; }
 
-/* line 766, ../../sass/_pages.sass */
 .chat-user {
   padding: 8px 10px;
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 771, ../../sass/_pages.sass */
 .chat-user a {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 775, ../../sass/_pages.sass */
 .chat-view {
-  z-index: 20012;
-}
+  z-index: 20012; }
 
-/* line 779, ../../sass/_pages.sass */
 .chat-users, .chat-statistic {
-  margin-left: -30px;
-}
+  margin-left: -30px; }
 
 @media (max-width: 992px) {
-  /* line 784, ../../sass/_pages.sass */
   .chat-users, .chat-statistic {
-    margin-left: 0;
-  }
-}
-/* line 789, ../../sass/_pages.sass */
+    margin-left: 0; } }
 .chat-view .ibox-content {
-  padding: 0;
-}
+  padding: 0; }
 
-/* line 793, ../../sass/_pages.sass */
 .chat-message {
-  padding: 10px 20px;
-}
+  padding: 10px 20px; }
 
-/* line 797, ../../sass/_pages.sass */
 .message-avatar {
   height: 48px;
   width: 48px;
   border: 1px solid #e7eaec;
   border-radius: 4px;
-  margin-top: 1px;
-}
+  margin-top: 1px; }
 
-/* line 805, ../../sass/_pages.sass */
 .chat-discussion .chat-message.left .message-avatar {
   float: left;
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 810, ../../sass/_pages.sass */
 .chat-discussion .chat-message.right .message-avatar {
   float: right;
-  margin-left: 10px;
-}
+  margin-left: 10px; }
 
-/* line 815, ../../sass/_pages.sass */
 .message {
   background-color: #fff;
   border: 1px solid #e7eaec;
@@ -7017,386 +4793,256 @@ dd.project-people {
   display: block;
   padding: 10px 20px;
   position: relative;
-  border-radius: 4px;
-}
+  border-radius: 4px; }
 
-/* line 825, ../../sass/_pages.sass */
 .chat-discussion .chat-message.left .message-date {
-  float: right;
-}
+  float: right; }
 
-/* line 829, ../../sass/_pages.sass */
 .chat-discussion .chat-message.right .message-date {
-  float: left;
-}
+  float: left; }
 
-/* line 833, ../../sass/_pages.sass */
 .chat-discussion .chat-message.left .message {
   text-align: left;
-  margin-left: 55px;
-}
+  margin-left: 55px; }
 
-/* line 838, ../../sass/_pages.sass */
 .chat-discussion .chat-message.right .message {
   text-align: right;
-  margin-right: 55px;
-}
+  margin-right: 55px; }
 
-/* line 843, ../../sass/_pages.sass */
 .message-date {
   font-size: 10px;
-  color: #888888;
-}
+  color: #888888; }
 
-/* line 848, ../../sass/_pages.sass */
 .message-content {
-  display: block;
-}
+  display: block; }
 
-/* line 852, ../../sass/_pages.sass */
 .chat-discussion {
   background: #eee;
   padding: 15px;
   height: 400px;
-  overflow-y: auto;
-}
+  overflow-y: auto; }
 
-/* line 859, ../../sass/_pages.sass */
 .chat-users {
   overflow-y: auto;
-  height: 400px;
-}
+  height: 400px; }
 
-/* line 864, ../../sass/_pages.sass */
 .chat-message-form .form-group {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
 /* jsTree */
-/* line 869, ../../sass/_pages.sass */
 .jstree-open > .jstree-anchor > .fa-folder:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 873, ../../sass/_pages.sass */
 .jstree-default .jstree-icon.none {
-  width: 0;
-}
+  width: 0; }
 
 /* CLIENTS */
-/* line 879, ../../sass/_pages.sass */
 .clients-list {
-  margin-top: 20px;
-}
+  margin-top: 20px; }
 
-/* line 883, ../../sass/_pages.sass */
 .clients-list .tab-pane {
   position: relative;
-  height: 600px;
-}
+  height: 600px; }
 
-/* line 888, ../../sass/_pages.sass */
 .client-detail {
   position: relative;
-  height: 620px;
-}
+  height: 620px; }
 
-/* line 893, ../../sass/_pages.sass */
 .clients-list table tr td {
   height: 46px;
   vertical-align: middle;
-  border: none;
-}
+  border: none; }
 
-/* line 899, ../../sass/_pages.sass */
 .client-link {
   font-weight: 600;
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 904, ../../sass/_pages.sass */
 .client-link:hover {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 908, ../../sass/_pages.sass */
 .client-avatar {
-  width: 42px;
-}
+  width: 42px; }
 
-/* line 912, ../../sass/_pages.sass */
 .client-avatar img {
   width: 28px;
   height: 28px;
-  border-radius: 50%;
-}
+  border-radius: 50%; }
 
-/* line 918, ../../sass/_pages.sass */
 .contact-type {
   width: 20px;
-  color: #c1c3c4;
-}
+  color: #c1c3c4; }
 
-/* line 923, ../../sass/_pages.sass */
 .client-status {
-  text-align: left;
-}
+  text-align: left; }
 
-/* line 927, ../../sass/_pages.sass */
 .client-detail .vertical-timeline-content p {
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 931, ../../sass/_pages.sass */
 .client-detail .vertical-timeline-icon.gray-bg {
-  color: #a7aaab;
-}
+  color: #a7aaab; }
 
-/* line 936, ../../sass/_pages.sass */
 .clients-list .nav-tabs > li.active > a, .clients-list .nav-tabs > li.active > a:hover, .clients-list .nav-tabs > li.active > a:focus {
-  border-bottom: 1px solid #fff;
-}
+  border-bottom: 1px solid #fff; }
 
 /* BLOG ARTICLE */
-/* line 942, ../../sass/_pages.sass */
 .blog h2 {
-  font-weight: 700;
-}
+  font-weight: 700; }
 
-/* line 946, ../../sass/_pages.sass */
 .blog h5 {
-  margin: 0 0 5px 0;
-}
+  margin: 0 0 5px 0; }
 
-/* line 950, ../../sass/_pages.sass */
 .blog .btn {
-  margin: 0 0 5px 0;
-}
+  margin: 0 0 5px 0; }
 
-/* line 954, ../../sass/_pages.sass */
 .article h1 {
   font-size: 48px;
   font-weight: 700;
-  color: #2F4050;
-}
+  color: #2F4050; }
 
-/* line 960, ../../sass/_pages.sass */
 .article p {
   font-size: 15px;
-  line-height: 26px;
-}
+  line-height: 26px; }
 
-/* line 965, ../../sass/_pages.sass */
 .article-title {
   text-align: center;
-  margin: 40px 0 100px 0;
-}
+  margin: 40px 0 100px 0; }
 
-/* line 970, ../../sass/_pages.sass */
 .article .ibox-content {
-  padding: 40px;
-}
+  padding: 40px; }
 
 /* ISSUE TRACKER */
-/* line 976, ../../sass/_pages.sass */
 .issue-tracker .btn-link {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 980, ../../sass/_pages.sass */
 table.issue-tracker tbody tr td {
   vertical-align: middle;
-  height: 50px;
-}
+  height: 50px; }
 
-/* line 985, ../../sass/_pages.sass */
 .issue-info {
-  width: 50%;
-}
+  width: 50%; }
 
-/* line 989, ../../sass/_pages.sass */
 .issue-info a {
   font-weight: 600;
-  color: #676a6c;
-}
+  color: #676a6c; }
 
-/* line 994, ../../sass/_pages.sass */
 .issue-info small {
-  display: block;
-}
+  display: block; }
 
 /* TEAMS */
-/* line 999, ../../sass/_pages.sass */
 .team-members {
-  margin: 10px 0;
-}
+  margin: 10px 0; }
 
-/* line 1003, ../../sass/_pages.sass */
 .team-members img.img-circle {
   width: 42px;
   height: 42px;
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
 /* AGILE BOARD */
-/* line 1011, ../../sass/_pages.sass */
 .sortable-list {
-  padding: 10px 0;
-}
+  padding: 10px 0; }
 
-/* line 1015, ../../sass/_pages.sass */
 .agile-list {
   list-style: none;
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 1020, ../../sass/_pages.sass */
 .agile-list li {
   background: #FAFAFB;
   border: 1px solid #e7eaec;
   margin: 0 0 10px 0;
   padding: 10px;
-  border-radius: 2px;
-}
+  border-radius: 2px; }
 
-/* line 1029, ../../sass/_pages.sass */
 .agile-list li:hover {
   cursor: pointer;
-  background: #fff;
-}
+  background: #fff; }
 
-/* line 1034, ../../sass/_pages.sass */
 .agile-list li.warning-element {
-  border-left: 3px solid #f8ac59;
-}
+  border-left: 3px solid #f8ac59; }
 
-/* line 1038, ../../sass/_pages.sass */
 .agile-list li.danger-element {
-  border-left: 3px solid #ED5565;
-}
+  border-left: 3px solid #ED5565; }
 
-/* line 1042, ../../sass/_pages.sass */
 .agile-list li.info-element {
-  border-left: 3px solid #1c84c6;
-}
+  border-left: 3px solid #1c84c6; }
 
-/* line 1046, ../../sass/_pages.sass */
 .agile-list li.success-element {
-  border-left: 3px solid #1ab394;
-}
+  border-left: 3px solid #1ab394; }
 
-/* line 1050, ../../sass/_pages.sass */
 .agile-detail {
   margin-top: 5px;
-  font-size: 12px;
-}
+  font-size: 12px; }
 
 /* DIFF */
-/* line 1056, ../../sass/_pages.sass */
 ins {
   background-color: #c6ffc6;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
-/* line 1061, ../../sass/_pages.sass */
 del {
-  background-color: #ffc6c6;
-}
+  background-color: #ffc6c6; }
 
 /* E-commerce */
-/* line 1066, ../../sass/_pages.sass */
 .product-box {
   padding: 0;
-  border: 1px solid #e7eaec;
-}
+  border: 1px solid #e7eaec; }
 
-/* line 1072, ../../sass/_pages.sass */
 .product-box:hover,
 .product-box.active {
   border: 1px solid transparent;
   -webkit-box-shadow: 0 3px 7px 0 #a8a8a8;
   -moz-box-shadow: 0 3px 7px 0 #a8a8a8;
-  box-shadow: 0 3px 7px 0 #a8a8a8;
-}
+  box-shadow: 0 3px 7px 0 #a8a8a8; }
 
-/* line 1080, ../../sass/_pages.sass */
 .product-imitation {
   text-align: center;
   padding: 90px 0;
   background-color: #f8f8f9;
   color: #bebec3;
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 1088, ../../sass/_pages.sass */
 .cart-product-imitation {
   text-align: center;
   padding-top: 30px;
   height: 80px;
   width: 80px;
-  background-color: #f8f8f9;
-}
+  background-color: #f8f8f9; }
 
-/* line 1096, ../../sass/_pages.sass */
 .product-imitation.xl {
-  padding: 120px 0;
-}
+  padding: 120px 0; }
 
-/* line 1100, ../../sass/_pages.sass */
 .product-desc {
   padding: 20px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 1105, ../../sass/_pages.sass */
 .ecommerce .tag-list {
-  padding: 0;
-}
+  padding: 0; }
 
-/* line 1109, ../../sass/_pages.sass */
 .ecommerce .fa-star {
-  color: #D1DADE;
-}
+  color: #D1DADE; }
 
-/* line 1113, ../../sass/_pages.sass */
 .ecommerce .fa-star.active {
-  color: #f8ac59;
-}
+  color: #f8ac59; }
 
-/* line 1117, ../../sass/_pages.sass */
 .ecommerce .note-editor {
-  border: 1px solid #e7eaec;
-}
+  border: 1px solid #e7eaec; }
 
-/* line 1121, ../../sass/_pages.sass */
 table.shoping-cart-table {
-  margin-bottom: 0;
-}
-/* line 1124, ../../sass/_pages.sass */
-table.shoping-cart-table tr td {
-  border: none;
-}
-/* line 1128, ../../sass/_pages.sass */
-table.shoping-cart-table td.desc {
-  width: 60%;
-}
+  margin-bottom: 0; }
+  table.shoping-cart-table tr td {
+    border: none; }
+  table.shoping-cart-table td.desc {
+    width: 60%; }
 
-/* line 1134, ../../sass/_pages.sass */
 .product-name {
   font-size: 16px;
   font-weight: 600;
   color: #676a6c;
   display: block;
-  margin: 2px 0 5px 0;
-}
+  margin: 2px 0 5px 0; }
 
-/* line 1142, ../../sass/_pages.sass */
 .product-name:hover,
 .product-name:focus {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 1147, ../../sass/_pages.sass */
 .product-price {
   font-size: 14px;
   font-weight: 600;
@@ -7405,255 +5051,171 @@ table.shoping-cart-table td.desc {
   padding: 6px 12px;
   position: absolute;
   top: -32px;
-  right: 0;
-}
+  right: 0; }
 
-/* line 1159, ../../sass/_pages.sass */
 .product-detail .ibox-content {
-  padding: 30px 30px 50px 30px;
-}
+  padding: 30px 30px 50px 30px; }
 
-/* line 1163, ../../sass/_pages.sass */
 .image-imitation {
   background-color: #f8f8f9;
   text-align: center;
-  padding: 200px 0;
-}
+  padding: 200px 0; }
 
-/* line 1170, ../../sass/_pages.sass */
 .product-main-price small {
-  font-size: 10px;
-}
+  font-size: 10px; }
 
-/* line 1175, ../../sass/_pages.sass */
 .product-images {
-  margin: 0 20px;
-}
+  margin: 0 20px; }
 
 /* Social feed */
-/* line 1180, ../../sass/_pages.sass */
 .social-feed-separated .social-feed-box {
-  margin-left: 62px;
-}
+  margin-left: 62px; }
 
-/* line 1184, ../../sass/_pages.sass */
 .social-feed-separated .social-avatar {
   float: left;
-  padding: 0;
-}
+  padding: 0; }
 
-/* line 1189, ../../sass/_pages.sass */
 .social-feed-separated .social-avatar img {
   width: 52px;
   height: 52px;
-  border: 1px solid #e7eaec;
-}
+  border: 1px solid #e7eaec; }
 
-/* line 1195, ../../sass/_pages.sass */
 .social-feed-separated .social-feed-box .social-avatar {
   padding: 15px 15px 0 15px;
-  float: none;
-}
+  float: none; }
 
-/* line 1200, ../../sass/_pages.sass */
 .social-feed-box {
   /*padding: 15px */
   border: 1px solid #e7eaec;
   background: #fff;
-  margin-bottom: 15px;
-}
+  margin-bottom: 15px; }
 
-/* line 1207, ../../sass/_pages.sass */
 .article .social-feed-box {
   margin-bottom: 0;
-  border-bottom: none;
-}
+  border-bottom: none; }
 
-/* line 1212, ../../sass/_pages.sass */
 .article .social-feed-box:last-child {
   margin-bottom: 0;
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 1217, ../../sass/_pages.sass */
 .article .social-feed-box p {
   font-size: 13px;
-  line-height: 18px;
-}
+  line-height: 18px; }
 
-/* line 1222, ../../sass/_pages.sass */
 .social-action {
-  margin: 15px;
-}
+  margin: 15px; }
 
-/* line 1226, ../../sass/_pages.sass */
 .social-avatar {
-  padding: 15px 15px 0 15px;
-}
+  padding: 15px 15px 0 15px; }
 
-/* line 1230, ../../sass/_pages.sass */
 .social-comment .social-comment {
-  margin-left: 45px;
-}
+  margin-left: 45px; }
 
-/* line 1234, ../../sass/_pages.sass */
 .social-avatar img {
   height: 40px;
   width: 40px;
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 1240, ../../sass/_pages.sass */
 .social-avatar .media-body a {
   font-size: 14px;
-  display: block;
-}
+  display: block; }
 
-/* line 1245, ../../sass/_pages.sass */
 .social-body {
-  padding: 15px;
-}
+  padding: 15px; }
 
-/* line 1249, ../../sass/_pages.sass */
 .social-body img {
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
-/* line 1253, ../../sass/_pages.sass */
 .social-footer {
   border-top: 1px solid #e7eaec;
   padding: 10px 15px;
-  background: #f9f9f9;
-}
+  background: #f9f9f9; }
 
-/* line 1259, ../../sass/_pages.sass */
 .social-footer .social-comment img {
   width: 32px;
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 1264, ../../sass/_pages.sass */
 .social-comment:first-child {
-  margin-top: 0;
-}
+  margin-top: 0; }
 
-/* line 1268, ../../sass/_pages.sass */
 .social-comment {
-  margin-top: 15px;
-}
+  margin-top: 15px; }
 
-/* line 1272, ../../sass/_pages.sass */
 .social-comment textarea {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
 /* Vote list */
-/* line 1278, ../../sass/_pages.sass */
 .vote-item {
   padding: 20px 25px;
   background: #ffffff;
-  border-top: 1px solid #e7eaec;
-}
+  border-top: 1px solid #e7eaec; }
 
-/* line 1284, ../../sass/_pages.sass */
 .vote-item:last-child {
-  border-bottom: 1px solid #e7eaec;
-}
+  border-bottom: 1px solid #e7eaec; }
 
-/* line 1288, ../../sass/_pages.sass */
 .vote-item:hover {
-  background: #fbfbfb;
-}
+  background: #fbfbfb; }
 
-/* line 1292, ../../sass/_pages.sass */
 .vote-actions {
   float: left;
   width: 30px;
   margin-right: 15px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 1300, ../../sass/_pages.sass */
 .vote-actions a {
   color: #1ab394;
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 1305, ../../sass/_pages.sass */
 .vote-actions {
-  font-weight: 600;
-}
+  font-weight: 600; }
 
-/* line 1309, ../../sass/_pages.sass */
 .vote-title {
   display: block;
   color: inherit;
   font-size: 18px;
   font-weight: 600;
   margin-top: 5px;
-  margin-bottom: 2px;
-}
+  margin-bottom: 2px; }
 
-/* line 1318, ../../sass/_pages.sass */
 .vote-title:hover, .vote-title:focus {
-  color: inherit;
-}
+  color: inherit; }
 
-/* line 1322, ../../sass/_pages.sass */
 .vote-info, .vote-title {
-  margin-left: 45px;
-}
+  margin-left: 45px; }
 
-/* line 1326, ../../sass/_pages.sass */
 .vote-info, .vote-info a {
   color: #b4b6b8;
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 1331, ../../sass/_pages.sass */
 .vote-info a {
-  margin-right: 10px;
-}
+  margin-right: 10px; }
 
-/* line 1335, ../../sass/_pages.sass */
 .vote-info a:hover {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 1339, ../../sass/_pages.sass */
 .vote-icon {
   text-align: right;
   font-size: 38px;
   display: block;
-  color: #e8e9ea;
-}
+  color: #e8e9ea; }
 
-/* line 1346, ../../sass/_pages.sass */
 .vote-icon.active {
-  color: #1ab394;
-}
+  color: #1ab394; }
 
-/* line 1350, ../../sass/_pages.sass */
 body.body-small .vote-icon {
-  display: none;
-}
+  display: none; }
 
-/* line 1, ../../sass/_chat.sass */
 #small-chat {
   position: fixed;
   bottom: 20px;
   right: 20px;
-  z-index: 100;
-}
+  z-index: 100; }
 
-/* line 8, ../../sass/_chat.sass */
 #small-chat .badge {
   position: absolute;
   top: -3px;
-  right: -4px;
-}
+  right: -4px; }
 
-/* line 14, ../../sass/_chat.sass */
 .open-small-chat {
   height: 38px;
   width: 38px;
@@ -7662,16 +5224,12 @@ body.body-small .vote-icon {
   padding: 9px 8px;
   text-align: center;
   color: #fff;
-  border-radius: 50%;
-}
+  border-radius: 50%; }
 
-/* line 25, ../../sass/_chat.sass */
 .open-small-chat:hover {
   color: white;
-  background: #1ab394;
-}
+  background: #1ab394; }
 
-/* line 30, ../../sass/_chat.sass */
 .small-chat-box {
   display: none;
   position: fixed;
@@ -7681,89 +5239,58 @@ body.body-small .vote-icon {
   border: 1px solid #e7eaec;
   width: 230px;
   height: 320px;
-  border-radius: 4px;
-}
+  border-radius: 4px; }
 
-/* line 42, ../../sass/_chat.sass */
 .small-chat-box.ng-small-chat {
-  display: block;
-}
+  display: block; }
 
-/* line 47, ../../sass/_chat.sass */
 .body-small .small-chat-box {
   bottom: 70px;
-  right: 20px;
-}
+  right: 20px; }
 
-/* line 53, ../../sass/_chat.sass */
 .small-chat-box.active {
-  display: block;
-}
+  display: block; }
 
-/* line 59, ../../sass/_chat.sass */
 .small-chat-box .heading {
   background: #2F4050;
   padding: 8px 15px;
   font-weight: bold;
-  color: #fff;
-}
-/* line 66, ../../sass/_chat.sass */
+  color: #fff; }
 .small-chat-box .chat-date {
   opacity: 0.6;
   font-size: 10px;
-  font-weight: normal;
-}
-/* line 72, ../../sass/_chat.sass */
+  font-weight: normal; }
 .small-chat-box .content {
-  padding: 15px 15px;
-}
-/* line 75, ../../sass/_chat.sass */
-.small-chat-box .content .author-name {
-  font-weight: bold;
-  margin-bottom: 3px;
-  font-size: 11px;
-}
-/* line 81, ../../sass/_chat.sass */
-.small-chat-box .content > div {
-  padding-bottom: 20px;
-}
-/* line 85, ../../sass/_chat.sass */
-.small-chat-box .content .chat-message {
-  padding: 5px 10px;
-  border-radius: 6px;
-  font-size: 11px;
-  line-height: 14px;
-  max-width: 80%;
-  background: #f3f3f4;
-  margin-bottom: 10px;
-}
-/* line 95, ../../sass/_chat.sass */
-.small-chat-box .content .chat-message.active {
-  background: #1ab394;
-  color: #fff;
-}
-/* line 100, ../../sass/_chat.sass */
-.small-chat-box .content .left {
-  text-align: left;
-  clear: both;
-}
-/* line 104, ../../sass/_chat.sass */
-.small-chat-box .content .left .chat-message {
-  float: left;
-}
-/* line 109, ../../sass/_chat.sass */
-.small-chat-box .content .right {
-  text-align: right;
-  clear: both;
-}
-/* line 113, ../../sass/_chat.sass */
-.small-chat-box .content .right .chat-message {
-  float: right;
-}
-/* line 121, ../../sass/_chat.sass */
+  padding: 15px 15px; }
+  .small-chat-box .content .author-name {
+    font-weight: bold;
+    margin-bottom: 3px;
+    font-size: 11px; }
+  .small-chat-box .content > div {
+    padding-bottom: 20px; }
+  .small-chat-box .content .chat-message {
+    padding: 5px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    line-height: 14px;
+    max-width: 80%;
+    background: #f3f3f4;
+    margin-bottom: 10px; }
+  .small-chat-box .content .chat-message.active {
+    background: #1ab394;
+    color: #fff; }
+  .small-chat-box .content .left {
+    text-align: left;
+    clear: both; }
+    .small-chat-box .content .left .chat-message {
+      float: left; }
+  .small-chat-box .content .right {
+    text-align: right;
+    clear: both; }
+    .small-chat-box .content .right .chat-message {
+      float: right; }
 .small-chat-box .form-chat {
-  padding: 10px 10px;
-}
+  padding: 10px 10px; }
 
 /* metismenu - v2.0.2
  * A jQuery menu plugin
@@ -7772,75 +5299,48 @@ body.body-small .vote-icon {
  * Made by Osman Nuri Okumus
  * Under MIT License
  */
-/* line 10, ../../sass/_metismenu.sass */
 .metismenu .plus-minus, .metismenu .plus-times {
-  float: right;
-}
+  float: right; }
 
-/* line 14, ../../sass/_metismenu.sass */
 .metismenu .arrow {
   float: right;
-  line-height: 1.42857;
-}
+  line-height: 1.42857; }
 
-/* line 19, ../../sass/_metismenu.sass */
 .metismenu .glyphicon.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 23, ../../sass/_metismenu.sass */
 .metismenu .active > a > .glyphicon.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 27, ../../sass/_metismenu.sass */
 .metismenu .fa.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 31, ../../sass/_metismenu.sass */
 .metismenu .active > a > .fa.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 35, ../../sass/_metismenu.sass */
 .metismenu .ion.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 39, ../../sass/_metismenu.sass */
 .metismenu .active > a > .ion.arrow:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 43, ../../sass/_metismenu.sass */
 .metismenu .fa.plus-minus:before, .metismenu .fa.plus-times:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 47, ../../sass/_metismenu.sass */
 .metismenu .active > a > .fa.plus-times {
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
-  transform: rotate(45deg);
-}
+  transform: rotate(45deg); }
 
-/* line 53, ../../sass/_metismenu.sass */
 .metismenu .active > a > .fa.plus-minus:before {
-  content: "";
-}
+  content: ""; }
 
-/* line 57, ../../sass/_metismenu.sass */
 .metismenu .collapse {
-  display: none;
-}
+  display: none; }
 
-/* line 61, ../../sass/_metismenu.sass */
 .metismenu .collapse.in {
-  display: block;
-}
+  display: block; }
 
-/* line 65, ../../sass/_metismenu.sass */
 .metismenu .collapsing {
   position: relative;
   height: 0;
@@ -7850,69 +5350,50 @@ body.body-small .vote-icon {
   -webkit-transition-duration: 0.35s;
   transition-duration: 0.35s;
   -webkit-transition-property: height, visibility;
-  transition-property: height, visibility;
-}
+  transition-property: height, visibility; }
 
-/* line 78, ../../sass/_metismenu.sass */
 .mini-navbar .metismenu .collapse {
-  opacity: 0;
-}
-/* line 81, ../../sass/_metismenu.sass */
+  opacity: 0; }
 .mini-navbar .metismenu .collapse.in {
-  opacity: 1;
-}
-/* line 84, ../../sass/_metismenu.sass */
+  opacity: 1; }
 .mini-navbar .metismenu .collapse a {
-  display: none;
-}
-/* line 87, ../../sass/_metismenu.sass */
+  display: none; }
 .mini-navbar .metismenu .collapse.in a {
-  display: block;
-}
+  display: block; }
 
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-rotating-plane"></div>
  *
  */
-/* line 8, ../../sass/_spinners.sass */
 .sk-spinner-rotating-plane.sk-spinner {
   width: 30px;
   height: 30px;
   background-color: #1ab394;
   margin: 0 auto;
   -webkit-animation: sk-rotatePlane 1.2s infinite ease-in-out;
-  animation: sk-rotatePlane 1.2s infinite ease-in-out;
-}
+  animation: sk-rotatePlane 1.2s infinite ease-in-out; }
 
 @-webkit-keyframes sk-rotatePlane {
   0% {
     -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg);
-    transform: perspective(120px) rotateX(0deg) rotateY(0deg);
-  }
+    transform: perspective(120px) rotateX(0deg) rotateY(0deg); }
   50% {
     -webkit-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
-    transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
-  }
+    transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg); }
   100% {
     -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
-    transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
-  }
-}
+    transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg); } }
 @keyframes sk-rotatePlane {
   0% {
     -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg);
-    transform: perspective(120px) rotateX(0deg) rotateY(0deg);
-  }
+    transform: perspective(120px) rotateX(0deg) rotateY(0deg); }
   50% {
     -webkit-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
-    transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
-  }
+    transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg); }
   100% {
     -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
-    transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
-  }
-}
+    transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-double-bounce">
@@ -7921,15 +5402,12 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 60, ../../sass/_spinners.sass */
 .sk-spinner-double-bounce.sk-spinner {
   width: 40px;
   height: 40px;
   position: relative;
-  margin: 0 auto;
-}
+  margin: 0 auto; }
 
-/* line 67, ../../sass/_spinners.sass */
 .sk-spinner-double-bounce .sk-double-bounce1, .sk-spinner-double-bounce .sk-double-bounce2 {
   width: 100%;
   height: 100%;
@@ -7940,35 +5418,26 @@ body.body-small .vote-icon {
   top: 0;
   left: 0;
   -webkit-animation: sk-doubleBounce 2s infinite ease-in-out;
-  animation: sk-doubleBounce 2s infinite ease-in-out;
-}
+  animation: sk-doubleBounce 2s infinite ease-in-out; }
 
-/* line 80, ../../sass/_spinners.sass */
 .sk-spinner-double-bounce .sk-double-bounce2 {
   -webkit-animation-delay: -1s;
-  animation-delay: -1s;
-}
+  animation-delay: -1s; }
 
 @-webkit-keyframes sk-doubleBounce {
   0%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   50% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 @keyframes sk-doubleBounce {
   0%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   50% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-wave">
@@ -7980,69 +5449,51 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 121, ../../sass/_spinners.sass */
 .sk-spinner-wave.sk-spinner {
   margin: 0 auto;
   width: 50px;
   height: 30px;
   text-align: center;
-  font-size: 10px;
-}
+  font-size: 10px; }
 
-/* line 129, ../../sass/_spinners.sass */
 .sk-spinner-wave div {
   background-color: #1ab394;
   height: 100%;
   width: 6px;
   display: inline-block;
   -webkit-animation: sk-waveStretchDelay 1.2s infinite ease-in-out;
-  animation: sk-waveStretchDelay 1.2s infinite ease-in-out;
-}
+  animation: sk-waveStretchDelay 1.2s infinite ease-in-out; }
 
-/* line 138, ../../sass/_spinners.sass */
 .sk-spinner-wave .sk-rect2 {
   -webkit-animation-delay: -1.1s;
-  animation-delay: -1.1s;
-}
+  animation-delay: -1.1s; }
 
-/* line 143, ../../sass/_spinners.sass */
 .sk-spinner-wave .sk-rect3 {
   -webkit-animation-delay: -1s;
-  animation-delay: -1s;
-}
+  animation-delay: -1s; }
 
-/* line 148, ../../sass/_spinners.sass */
 .sk-spinner-wave .sk-rect4 {
   -webkit-animation-delay: -0.9s;
-  animation-delay: -0.9s;
-}
+  animation-delay: -0.9s; }
 
-/* line 153, ../../sass/_spinners.sass */
 .sk-spinner-wave .sk-rect5 {
   -webkit-animation-delay: -0.8s;
-  animation-delay: -0.8s;
-}
+  animation-delay: -0.8s; }
 
 @-webkit-keyframes sk-waveStretchDelay {
   0%, 40%, 100% {
     -webkit-transform: scaleY(0.4);
-    transform: scaleY(0.4);
-  }
+    transform: scaleY(0.4); }
   20% {
     -webkit-transform: scaleY(1);
-    transform: scaleY(1);
-  }
-}
+    transform: scaleY(1); } }
 @keyframes sk-waveStretchDelay {
   0%, 40%, 100% {
     -webkit-transform: scaleY(0.4);
-    transform: scaleY(0.4);
-  }
+    transform: scaleY(0.4); }
   20% {
     -webkit-transform: scaleY(1);
-    transform: scaleY(1);
-  }
-}
+    transform: scaleY(1); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-wandering-cubes">
@@ -8051,15 +5502,12 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 191, ../../sass/_spinners.sass */
 .sk-spinner-wandering-cubes.sk-spinner {
   margin: 0 auto;
   width: 32px;
   height: 32px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 198, ../../sass/_spinners.sass */
 .sk-spinner-wandering-cubes .sk-cube1, .sk-spinner-wandering-cubes .sk-cube2 {
   background-color: #1ab394;
   width: 10px;
@@ -8068,67 +5516,51 @@ body.body-small .vote-icon {
   top: 0;
   left: 0;
   -webkit-animation: sk-wanderingCubeMove 1.8s infinite ease-in-out;
-  animation: sk-wanderingCubeMove 1.8s infinite ease-in-out;
-}
+  animation: sk-wanderingCubeMove 1.8s infinite ease-in-out; }
 
-/* line 209, ../../sass/_spinners.sass */
 .sk-spinner-wandering-cubes .sk-cube2 {
   -webkit-animation-delay: -0.9s;
-  animation-delay: -0.9s;
-}
+  animation-delay: -0.9s; }
 
 @-webkit-keyframes sk-wanderingCubeMove {
   25% {
     -webkit-transform: translateX(42px) rotate(-90deg) scale(0.5);
-    transform: translateX(42px) rotate(-90deg) scale(0.5);
-  }
+    transform: translateX(42px) rotate(-90deg) scale(0.5); }
   50% {
     /* Hack to make FF rotate in the right direction */
     -webkit-transform: translateX(42px) translateY(42px) rotate(-179deg);
-    transform: translateX(42px) translateY(42px) rotate(-179deg);
-  }
+    transform: translateX(42px) translateY(42px) rotate(-179deg); }
   50.1% {
     -webkit-transform: translateX(42px) translateY(42px) rotate(-180deg);
-    transform: translateX(42px) translateY(42px) rotate(-180deg);
-  }
+    transform: translateX(42px) translateY(42px) rotate(-180deg); }
   75% {
     -webkit-transform: translateX(0px) translateY(42px) rotate(-270deg) scale(0.5);
-    transform: translateX(0px) translateY(42px) rotate(-270deg) scale(0.5);
-  }
+    transform: translateX(0px) translateY(42px) rotate(-270deg) scale(0.5); }
   100% {
     -webkit-transform: rotate(-360deg);
-    transform: rotate(-360deg);
-  }
-}
+    transform: rotate(-360deg); } }
 @keyframes sk-wanderingCubeMove {
   25% {
     -webkit-transform: translateX(42px) rotate(-90deg) scale(0.5);
-    transform: translateX(42px) rotate(-90deg) scale(0.5);
-  }
+    transform: translateX(42px) rotate(-90deg) scale(0.5); }
   50% {
     /* Hack to make FF rotate in the right direction */
     -webkit-transform: translateX(42px) translateY(42px) rotate(-179deg);
-    transform: translateX(42px) translateY(42px) rotate(-179deg);
-  }
+    transform: translateX(42px) translateY(42px) rotate(-179deg); }
   50.1% {
     -webkit-transform: translateX(42px) translateY(42px) rotate(-180deg);
-    transform: translateX(42px) translateY(42px) rotate(-180deg);
-  }
+    transform: translateX(42px) translateY(42px) rotate(-180deg); }
   75% {
     -webkit-transform: translateX(0px) translateY(42px) rotate(-270deg) scale(0.5);
-    transform: translateX(0px) translateY(42px) rotate(-270deg) scale(0.5);
-  }
+    transform: translateX(0px) translateY(42px) rotate(-270deg) scale(0.5); }
   100% {
     -webkit-transform: rotate(-360deg);
-    transform: rotate(-360deg);
-  }
-}
+    transform: rotate(-360deg); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-pulse"></div>
  *
  */
-/* line 276, ../../sass/_spinners.sass */
 .sk-spinner-pulse.sk-spinner {
   width: 40px;
   height: 40px;
@@ -8136,31 +5568,24 @@ body.body-small .vote-icon {
   background-color: #1ab394;
   border-radius: 100%;
   -webkit-animation: sk-pulseScaleOut 1s infinite ease-in-out;
-  animation: sk-pulseScaleOut 1s infinite ease-in-out;
-}
+  animation: sk-pulseScaleOut 1s infinite ease-in-out; }
 
 @-webkit-keyframes sk-pulseScaleOut {
   0% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   100% {
     -webkit-transform: scale(1);
     transform: scale(1);
-    opacity: 0;
-  }
-}
+    opacity: 0; } }
 @keyframes sk-pulseScaleOut {
   0% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   100% {
     -webkit-transform: scale(1);
     transform: scale(1);
-    opacity: 0;
-  }
-}
+    opacity: 0; } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-chasing-dots">
@@ -8169,7 +5594,6 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 321, ../../sass/_spinners.sass */
 .sk-spinner-chasing-dots.sk-spinner {
   margin: 0 auto;
   width: 40px;
@@ -8177,10 +5601,8 @@ body.body-small .vote-icon {
   position: relative;
   text-align: center;
   -webkit-animation: sk-chasingDotsRotate 2s infinite linear;
-  animation: sk-chasingDotsRotate 2s infinite linear;
-}
+  animation: sk-chasingDotsRotate 2s infinite linear; }
 
-/* line 331, ../../sass/_spinners.sass */
 .sk-spinner-chasing-dots .sk-dot1, .sk-spinner-chasing-dots .sk-dot2 {
   width: 60%;
   height: 60%;
@@ -8190,49 +5612,36 @@ body.body-small .vote-icon {
   background-color: #1ab394;
   border-radius: 100%;
   -webkit-animation: sk-chasingDotsBounce 2s infinite ease-in-out;
-  animation: sk-chasingDotsBounce 2s infinite ease-in-out;
-}
+  animation: sk-chasingDotsBounce 2s infinite ease-in-out; }
 
-/* line 343, ../../sass/_spinners.sass */
 .sk-spinner-chasing-dots .sk-dot2 {
   top: auto;
   bottom: 0;
   -webkit-animation-delay: -1s;
-  animation-delay: -1s;
-}
+  animation-delay: -1s; }
 
 @-webkit-keyframes sk-chasingDotsRotate {
   100% {
     -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
+    transform: rotate(360deg); } }
 @keyframes sk-chasingDotsRotate {
   100% {
     -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
+    transform: rotate(360deg); } }
 @-webkit-keyframes sk-chasingDotsBounce {
   0%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   50% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 @keyframes sk-chasingDotsBounce {
   0%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   50% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-three-bounce">
@@ -8242,14 +5651,11 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 398, ../../sass/_spinners.sass */
 .sk-spinner-three-bounce.sk-spinner {
   margin: 0 auto;
   width: 70px;
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 404, ../../sass/_spinners.sass */
 .sk-spinner-three-bounce div {
   width: 18px;
   height: 18px;
@@ -8260,41 +5666,30 @@ body.body-small .vote-icon {
   animation: sk-threeBounceDelay 1.4s infinite ease-in-out;
   /* Prevent first frame from flickering when animation starts */
   -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-}
+  animation-fill-mode: both; }
 
-/* line 417, ../../sass/_spinners.sass */
 .sk-spinner-three-bounce .sk-bounce1 {
   -webkit-animation-delay: -0.32s;
-  animation-delay: -0.32s;
-}
+  animation-delay: -0.32s; }
 
-/* line 422, ../../sass/_spinners.sass */
 .sk-spinner-three-bounce .sk-bounce2 {
   -webkit-animation-delay: -0.16s;
-  animation-delay: -0.16s;
-}
+  animation-delay: -0.16s; }
 
 @-webkit-keyframes sk-threeBounceDelay {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   40% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 @keyframes sk-threeBounceDelay {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   40% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-circle">
@@ -8313,24 +5708,19 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 470, ../../sass/_spinners.sass */
 .sk-spinner-circle.sk-spinner {
   margin: 0 auto;
   width: 22px;
   height: 22px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 477, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle {
   width: 100%;
   height: 100%;
   position: absolute;
   left: 0;
-  top: 0;
-}
+  top: 0; }
 
-/* line 485, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle:before {
   content: "";
   display: block;
@@ -8343,172 +5733,121 @@ body.body-small .vote-icon {
   animation: sk-circleBounceDelay 1.2s infinite ease-in-out;
   /* Prevent first frame from flickering when animation starts */
   -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-}
+  animation-fill-mode: both; }
 
-/* line 500, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle2 {
   -webkit-transform: rotate(30deg);
   -ms-transform: rotate(30deg);
-  transform: rotate(30deg);
-}
+  transform: rotate(30deg); }
 
-/* line 506, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle3 {
   -webkit-transform: rotate(60deg);
   -ms-transform: rotate(60deg);
-  transform: rotate(60deg);
-}
+  transform: rotate(60deg); }
 
-/* line 512, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle4 {
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
-}
+  transform: rotate(90deg); }
 
-/* line 518, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle5 {
   -webkit-transform: rotate(120deg);
   -ms-transform: rotate(120deg);
-  transform: rotate(120deg);
-}
+  transform: rotate(120deg); }
 
-/* line 524, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle6 {
   -webkit-transform: rotate(150deg);
   -ms-transform: rotate(150deg);
-  transform: rotate(150deg);
-}
+  transform: rotate(150deg); }
 
-/* line 530, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle7 {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-}
+  transform: rotate(180deg); }
 
-/* line 536, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle8 {
   -webkit-transform: rotate(210deg);
   -ms-transform: rotate(210deg);
-  transform: rotate(210deg);
-}
+  transform: rotate(210deg); }
 
-/* line 542, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle9 {
   -webkit-transform: rotate(240deg);
   -ms-transform: rotate(240deg);
-  transform: rotate(240deg);
-}
+  transform: rotate(240deg); }
 
-/* line 548, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle10 {
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
-  transform: rotate(270deg);
-}
+  transform: rotate(270deg); }
 
-/* line 554, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle11 {
   -webkit-transform: rotate(300deg);
   -ms-transform: rotate(300deg);
-  transform: rotate(300deg);
-}
+  transform: rotate(300deg); }
 
-/* line 560, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle12 {
   -webkit-transform: rotate(330deg);
   -ms-transform: rotate(330deg);
-  transform: rotate(330deg);
-}
+  transform: rotate(330deg); }
 
-/* line 566, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle2:before {
   -webkit-animation-delay: -1.1s;
-  animation-delay: -1.1s;
-}
+  animation-delay: -1.1s; }
 
-/* line 571, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle3:before {
   -webkit-animation-delay: -1s;
-  animation-delay: -1s;
-}
+  animation-delay: -1s; }
 
-/* line 576, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle4:before {
   -webkit-animation-delay: -0.9s;
-  animation-delay: -0.9s;
-}
+  animation-delay: -0.9s; }
 
-/* line 581, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle5:before {
   -webkit-animation-delay: -0.8s;
-  animation-delay: -0.8s;
-}
+  animation-delay: -0.8s; }
 
-/* line 586, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle6:before {
   -webkit-animation-delay: -0.7s;
-  animation-delay: -0.7s;
-}
+  animation-delay: -0.7s; }
 
-/* line 591, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle7:before {
   -webkit-animation-delay: -0.6s;
-  animation-delay: -0.6s;
-}
+  animation-delay: -0.6s; }
 
-/* line 596, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle8:before {
   -webkit-animation-delay: -0.5s;
-  animation-delay: -0.5s;
-}
+  animation-delay: -0.5s; }
 
-/* line 601, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle9:before {
   -webkit-animation-delay: -0.4s;
-  animation-delay: -0.4s;
-}
+  animation-delay: -0.4s; }
 
-/* line 606, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle10:before {
   -webkit-animation-delay: -0.3s;
-  animation-delay: -0.3s;
-}
+  animation-delay: -0.3s; }
 
-/* line 611, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle11:before {
   -webkit-animation-delay: -0.2s;
-  animation-delay: -0.2s;
-}
+  animation-delay: -0.2s; }
 
-/* line 616, ../../sass/_spinners.sass */
 .sk-spinner-circle .sk-circle12:before {
   -webkit-animation-delay: -0.1s;
-  animation-delay: -0.1s;
-}
+  animation-delay: -0.1s; }
 
 @-webkit-keyframes sk-circleBounceDelay {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   40% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 @keyframes sk-circleBounceDelay {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
-    transform: scale(0);
-  }
+    transform: scale(0); }
   40% {
     -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
+    transform: scale(1); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-cube-grid">
@@ -8524,106 +5863,76 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 661, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid {
   /* Spinner positions
    * 1 2 3
    * 4 5 6
    * 7 8 9
-   */
-}
+   */ }
 
-/* line 670, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid.sk-spinner {
   width: 30px;
   height: 30px;
-  margin: 0 auto;
-}
+  margin: 0 auto; }
 
-/* line 676, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube {
   width: 33%;
   height: 33%;
   background-color: #1ab394;
   float: left;
   -webkit-animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
-  animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
-}
+  animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out; }
 
-/* line 685, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(1) {
   -webkit-animation-delay: 0.2s;
-  animation-delay: 0.2s;
-}
+  animation-delay: 0.2s; }
 
-/* line 690, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(2) {
   -webkit-animation-delay: 0.3s;
-  animation-delay: 0.3s;
-}
+  animation-delay: 0.3s; }
 
-/* line 695, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(3) {
   -webkit-animation-delay: 0.4s;
-  animation-delay: 0.4s;
-}
+  animation-delay: 0.4s; }
 
-/* line 700, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(4) {
   -webkit-animation-delay: 0.1s;
-  animation-delay: 0.1s;
-}
+  animation-delay: 0.1s; }
 
-/* line 705, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(5) {
   -webkit-animation-delay: 0.2s;
-  animation-delay: 0.2s;
-}
+  animation-delay: 0.2s; }
 
-/* line 710, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(6) {
   -webkit-animation-delay: 0.3s;
-  animation-delay: 0.3s;
-}
+  animation-delay: 0.3s; }
 
-/* line 715, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(7) {
   -webkit-animation-delay: 0s;
-  animation-delay: 0s;
-}
+  animation-delay: 0s; }
 
-/* line 720, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(8) {
   -webkit-animation-delay: 0.1s;
-  animation-delay: 0.1s;
-}
+  animation-delay: 0.1s; }
 
-/* line 725, ../../sass/_spinners.sass */
 .sk-spinner-cube-grid .sk-cube:nth-child(9) {
   -webkit-animation-delay: 0.2s;
-  animation-delay: 0.2s;
-}
+  animation-delay: 0.2s; }
 
 @-webkit-keyframes sk-cubeGridScaleDelay {
   0%, 70%, 100% {
     -webkit-transform: scale3D(1, 1, 1);
-    transform: scale3D(1, 1, 1);
-  }
+    transform: scale3D(1, 1, 1); }
   35% {
     -webkit-transform: scale3D(0, 0, 1);
-    transform: scale3D(0, 0, 1);
-  }
-}
+    transform: scale3D(0, 0, 1); } }
 @keyframes sk-cubeGridScaleDelay {
   0%, 70%, 100% {
     -webkit-transform: scale3D(1, 1, 1);
-    transform: scale3D(1, 1, 1);
-  }
+    transform: scale3D(1, 1, 1); }
   35% {
     -webkit-transform: scale3D(0, 0, 1);
-    transform: scale3D(0, 0, 1);
-  }
-}
+    transform: scale3D(0, 0, 1); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-wordpress">
@@ -8631,7 +5940,6 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 762, ../../sass/_spinners.sass */
 .sk-spinner-wordpress.sk-spinner {
   background-color: #1ab394;
   width: 30px;
@@ -8640,10 +5948,8 @@ body.body-small .vote-icon {
   position: relative;
   margin: 0 auto;
   -webkit-animation: sk-innerCircle 1s linear infinite;
-  animation: sk-innerCircle 1s linear infinite;
-}
+  animation: sk-innerCircle 1s linear infinite; }
 
-/* line 773, ../../sass/_spinners.sass */
 .sk-spinner-wordpress .sk-inner-circle {
   display: block;
   background-color: #fff;
@@ -8652,29 +5958,22 @@ body.body-small .vote-icon {
   position: absolute;
   border-radius: 8px;
   top: 5px;
-  left: 5px;
-}
+  left: 5px; }
 
 @-webkit-keyframes sk-innerCircle {
   0% {
     -webkit-transform: rotate(0);
-    transform: rotate(0);
-  }
+    transform: rotate(0); }
   100% {
     -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
+    transform: rotate(360deg); } }
 @keyframes sk-innerCircle {
   0% {
     -webkit-transform: rotate(0);
-    transform: rotate(0);
-  }
+    transform: rotate(0); }
   100% {
     -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
+    transform: rotate(360deg); } }
 /*  Usage:
  *
  *    <div class="sk-spinner sk-spinner-fading-circle">
@@ -8693,24 +5992,19 @@ body.body-small .vote-icon {
  *    </div>
  *
  */
-/* line 827, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle.sk-spinner {
   margin: 0 auto;
   width: 22px;
   height: 22px;
-  position: relative;
-}
+  position: relative; }
 
-/* line 834, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle {
   width: 100%;
   height: 100%;
   position: absolute;
   left: 0;
-  top: 0;
-}
+  top: 0; }
 
-/* line 842, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle:before {
   content: "";
   display: block;
@@ -8723,179 +6017,123 @@ body.body-small .vote-icon {
   animation: sk-circleFadeDelay 1.2s infinite ease-in-out;
   /* Prevent first frame from flickering when animation starts */
   -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-}
+  animation-fill-mode: both; }
 
-/* line 857, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle2 {
   -webkit-transform: rotate(30deg);
   -ms-transform: rotate(30deg);
-  transform: rotate(30deg);
-}
+  transform: rotate(30deg); }
 
-/* line 863, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle3 {
   -webkit-transform: rotate(60deg);
   -ms-transform: rotate(60deg);
-  transform: rotate(60deg);
-}
+  transform: rotate(60deg); }
 
-/* line 869, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle4 {
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
-}
+  transform: rotate(90deg); }
 
-/* line 875, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle5 {
   -webkit-transform: rotate(120deg);
   -ms-transform: rotate(120deg);
-  transform: rotate(120deg);
-}
+  transform: rotate(120deg); }
 
-/* line 881, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle6 {
   -webkit-transform: rotate(150deg);
   -ms-transform: rotate(150deg);
-  transform: rotate(150deg);
-}
+  transform: rotate(150deg); }
 
-/* line 887, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle7 {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-}
+  transform: rotate(180deg); }
 
-/* line 893, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle8 {
   -webkit-transform: rotate(210deg);
   -ms-transform: rotate(210deg);
-  transform: rotate(210deg);
-}
+  transform: rotate(210deg); }
 
-/* line 899, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle9 {
   -webkit-transform: rotate(240deg);
   -ms-transform: rotate(240deg);
-  transform: rotate(240deg);
-}
+  transform: rotate(240deg); }
 
-/* line 905, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle10 {
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
-  transform: rotate(270deg);
-}
+  transform: rotate(270deg); }
 
-/* line 911, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle11 {
   -webkit-transform: rotate(300deg);
   -ms-transform: rotate(300deg);
-  transform: rotate(300deg);
-}
+  transform: rotate(300deg); }
 
-/* line 917, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle12 {
   -webkit-transform: rotate(330deg);
   -ms-transform: rotate(330deg);
-  transform: rotate(330deg);
-}
+  transform: rotate(330deg); }
 
-/* line 923, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle2:before {
   -webkit-animation-delay: -1.1s;
-  animation-delay: -1.1s;
-}
+  animation-delay: -1.1s; }
 
-/* line 928, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle3:before {
   -webkit-animation-delay: -1s;
-  animation-delay: -1s;
-}
+  animation-delay: -1s; }
 
-/* line 933, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle4:before {
   -webkit-animation-delay: -0.9s;
-  animation-delay: -0.9s;
-}
+  animation-delay: -0.9s; }
 
-/* line 938, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle5:before {
   -webkit-animation-delay: -0.8s;
-  animation-delay: -0.8s;
-}
+  animation-delay: -0.8s; }
 
-/* line 943, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle6:before {
   -webkit-animation-delay: -0.7s;
-  animation-delay: -0.7s;
-}
+  animation-delay: -0.7s; }
 
-/* line 948, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle7:before {
   -webkit-animation-delay: -0.6s;
-  animation-delay: -0.6s;
-}
+  animation-delay: -0.6s; }
 
-/* line 953, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle8:before {
   -webkit-animation-delay: -0.5s;
-  animation-delay: -0.5s;
-}
+  animation-delay: -0.5s; }
 
-/* line 958, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle9:before {
   -webkit-animation-delay: -0.4s;
-  animation-delay: -0.4s;
-}
+  animation-delay: -0.4s; }
 
-/* line 963, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle10:before {
   -webkit-animation-delay: -0.3s;
-  animation-delay: -0.3s;
-}
+  animation-delay: -0.3s; }
 
-/* line 968, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle11:before {
   -webkit-animation-delay: -0.2s;
-  animation-delay: -0.2s;
-}
+  animation-delay: -0.2s; }
 
-/* line 973, ../../sass/_spinners.sass */
 .sk-spinner-fading-circle .sk-circle12:before {
   -webkit-animation-delay: -0.1s;
-  animation-delay: -0.1s;
-}
+  animation-delay: -0.1s; }
 
 @-webkit-keyframes sk-circleFadeDelay {
   0%, 39%, 100% {
-    opacity: 0;
-  }
+    opacity: 0; }
   40% {
-    opacity: 1;
-  }
-}
+    opacity: 1; } }
 @keyframes sk-circleFadeDelay {
   0%, 39%, 100% {
-    opacity: 0;
-  }
+    opacity: 0; }
   40% {
-    opacity: 1;
-  }
-}
-/* line 998, ../../sass/_spinners.sass */
+    opacity: 1; } }
 .ibox-content > .sk-spinner {
-  display: none;
-}
+  display: none; }
 
-/* line 1001, ../../sass/_spinners.sass */
 .ibox-content.sk-loading {
-  position: relative;
-}
+  position: relative; }
 
-/* line 1004, ../../sass/_spinners.sass */
 .ibox-content.sk-loading:after {
   content: "";
   background-color: rgba(255, 255, 255, 0.7);
@@ -8903,24 +6141,20 @@ body.body-small .vote-icon {
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
-}
+  bottom: 0; }
 
-/* line 1013, ../../sass/_spinners.sass */
 .ibox-content.sk-loading > .sk-spinner {
   display: block;
   position: absolute;
   top: 40%;
   left: 0;
   right: 0;
-  z-index: 2000;
-}
+  z-index: 2000; }
 
 /*
  *   INSPINIA Landing Page - Responsive Admin Theme
  *   Copyright 2014 Webapplayers.com
  */
-/* line 7, ../../sass/_landing.sass */
 .landing-page.pace .pace-progress {
   background: #fff;
   position: fixed;
@@ -8931,1028 +6165,652 @@ body.body-small .vote-icon {
   -webkit-transition: width 1s;
   -moz-transition: width 1s;
   -o-transition: width 1s;
-  transition: width 1s;
-}
+  transition: width 1s; }
 
-/* line 21, ../../sass/_landing.sass */
 .pace-inactive {
-  display: none;
-}
+  display: none; }
 
-/* line 25, ../../sass/_landing.sass */
 body.landing-page {
   color: #676a6c;
   font-family: "Open Sans", helvetica, arial, sans-serif;
-  background-color: #fff;
-}
+  background-color: #fff; }
 
-/* line 31, ../../sass/_landing.sass */
 .landing-page {
   /* Flip around the padding for proper display in narrow viewports */
   /* Carousel base class */
   /* Since positioning the image, we need to help out the caption */
   /* Declare heights because of positioning of img element */
   /* The navbar becomes detached from the top, so we round the corners */
-  /* Bump up size of carousel content */
-}
-/* line 33, ../../sass/_landing.sass */
-.landing-page .container {
-  overflow: hidden;
-}
-/* line 36, ../../sass/_landing.sass */
-.landing-page span.navy {
-  color: #1ab394;
-}
-/* line 39, ../../sass/_landing.sass */
-.landing-page p.text-color {
-  color: #676a6c;
-}
-/* line 42, ../../sass/_landing.sass */
-.landing-page a.navy-link {
-  color: #1ab394;
-  text-decoration: none;
-}
-/* line 46, ../../sass/_landing.sass */
-.landing-page a.navy-link:hover {
-  color: #179d82;
-}
-/* line 49, ../../sass/_landing.sass */
-.landing-page section p {
-  color: #aeaeae;
-  font-size: 13px;
-}
-/* line 53, ../../sass/_landing.sass */
-.landing-page address {
-  font-size: 13px;
-}
-/* line 56, ../../sass/_landing.sass */
-.landing-page h1 {
-  margin-top: 10px;
-  font-size: 30px;
-  font-weight: 200;
-}
-/* line 61, ../../sass/_landing.sass */
-.landing-page .navy-line {
-  width: 60px;
-  height: 1px;
-  margin: 60px auto 0;
-  border-bottom: 2px solid #1ab394;
-}
-/* line 68, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper {
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 200;
-}
-/* line 76, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper > .container {
-  padding-right: 0;
-  padding-left: 0;
-}
-/* line 80, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper .navbar {
-  padding-right: 15px;
-  padding-left: 15px;
-}
-/* line 84, ../../sass/_landing.sass */
-.landing-page .navbar-default.navbar-scroll {
-  background-color: #fff;
-  border-color: #fff;
-  padding: 15px 0;
-}
-/* line 89, ../../sass/_landing.sass */
-.landing-page .navbar-default {
-  background-color: transparent;
-  border-color: transparent;
-  transition: all 0.3s ease-in-out 0s;
-}
-/* line 94, ../../sass/_landing.sass */
-.landing-page .navbar-default .nav li a {
-  color: #fff;
-  font-family: "Open Sans", helvetica, arial, sans-serif;
-  font-weight: 700;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  font-size: 14px;
-}
-/* line 102, ../../sass/_landing.sass */
-.landing-page .navbar-nav > li > a {
-  padding-top: 25px;
-  border-top: 6px solid transparent;
-}
-/* line 106, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-nav > .active > a,
-.landing-page .navbar-default .navbar-nav > .active > a:hover {
-  background: transparent;
-  color: #fff;
-  border-top: 6px solid #1ab394;
-}
-/* line 112, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-nav > li > a:hover,
-.landing-page .navbar-default .navbar-nav > li > a:focus {
-  color: #1ab394;
-  background: inherit;
-}
-/* line 117, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-nav > .active > a:focus {
-  background: transparent;
-  color: #fff;
-}
-/* line 122, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-nav > .active > a:focus {
-  background: transparent;
-  color: #ffffff;
-}
-/* line 127, ../../sass/_landing.sass */
-.landing-page .navbar-default.navbar-scroll .navbar-nav > .active > a:focus {
-  background: transparent;
-  color: inherit;
-}
-/* line 131, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-brand:hover,
-.landing-page .navbar-default .navbar-brand:focus {
-  background: #179d82;
-  color: #fff;
-}
-/* line 136, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-brand {
-  color: #fff;
-  height: auto;
-  display: block;
-  font-size: 14px;
-  background: #1ab394;
-  padding: 15px 20px 15px 20px;
-  border-radius: 0 0 5px 5px;
-  font-weight: 700;
-  transition: all 0.3s ease-in-out 0s;
-}
-/* line 147, ../../sass/_landing.sass */
-.landing-page .navbar-scroll.navbar-default .nav li a {
-  color: #676a6c;
-}
-/* line 150, ../../sass/_landing.sass */
-.landing-page .navbar-scroll.navbar-default .nav li a:hover {
-  color: #1ab394;
-}
-/* line 153, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper .navbar.navbar-scroll {
-  padding-top: 0;
-  padding-bottom: 5px;
-  border-bottom: 1px solid #e7eaec;
-  border-radius: 0;
-}
-/* line 160, ../../sass/_landing.sass */
-.landing-page .nav > li.active {
-  border: none;
-  background: inherit;
-}
-/* line 165, ../../sass/_landing.sass */
-.landing-page .nav > li > a {
-  padding: 25px 10px 15px 10px;
-}
-/* line 168, ../../sass/_landing.sass */
-.landing-page .navbar-scroll .navbar-nav > li > a {
-  padding: 20px 10px;
-}
-/* line 172, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-nav > .active > a,
-.landing-page .navbar-default .navbar-nav > .active > a:hover {
-  border-top: 6px solid #1ab394;
-}
-/* line 177, ../../sass/_landing.sass */
-.landing-page .navbar-fixed-top {
-  border: none !important;
-}
-/* line 181, ../../sass/_landing.sass */
-.landing-page .navbar-fixed-top.navbar-scroll {
-  border-bottom: 1px solid #e7eaec !important;
-}
-/* line 185, ../../sass/_landing.sass */
-.landing-page .navbar.navbar-scroll .navbar-brand {
-  margin-top: 15px;
-  border-radius: 5px;
-  font-size: 12px;
-  padding: 10px;
-  height: auto;
-}
-/* line 193, ../../sass/_landing.sass */
-.landing-page .header-back {
-  height: 470px;
-  width: 100%;
-}
-/* line 197, ../../sass/_landing.sass */
-.landing-page .header-back.one {
-  background: url("../img/landing/header_one.jpg") 50% 0 no-repeat;
-}
-/* line 200, ../../sass/_landing.sass */
-.landing-page .header-back.two {
-  background: url("../img/landing/header_two.jpg") 50% 0 no-repeat;
-}
-/* line 204, ../../sass/_landing.sass */
-.landing-page .carousel {
-  height: 470px;
-}
-/* line 208, ../../sass/_landing.sass */
-.landing-page .carousel-caption {
-  z-index: 10;
-}
-/* line 212, ../../sass/_landing.sass */
-.landing-page .carousel .item {
-  height: 470px;
-  background-color: #777;
-}
-/* line 216, ../../sass/_landing.sass */
-.landing-page .carousel-inner > .item > img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  min-width: 100%;
-  height: 470px;
-}
-/* line 223, ../../sass/_landing.sass */
-.landing-page .carousel-fade .carousel-inner .item {
-  opacity: 0;
-  -webkit-transition-property: opacity;
-  transition-property: opacity;
-}
-/* line 228, ../../sass/_landing.sass */
-.landing-page .carousel-fade .carousel-inner .active {
-  opacity: 1;
-}
-/* line 231, ../../sass/_landing.sass */
-.landing-page .carousel-fade .carousel-inner .active.left,
-.landing-page .carousel-fade .carousel-inner .active.right {
-  left: 0;
-  opacity: 0;
-  z-index: 1;
-}
-/* line 237, ../../sass/_landing.sass */
-.landing-page .carousel-fade .carousel-inner .next.left,
-.landing-page .carousel-fade .carousel-inner .prev.right {
-  opacity: 1;
-}
-/* line 241, ../../sass/_landing.sass */
-.landing-page .carousel-fade .carousel-control {
-  z-index: 2;
-}
-/* line 244, ../../sass/_landing.sass */
-.landing-page .carousel-control.left,
-.landing-page .carousel-control.right {
-  background: none;
-}
-/* line 248, ../../sass/_landing.sass */
-.landing-page .carousel-control {
-  width: 6%;
-}
-/* line 251, ../../sass/_landing.sass */
-.landing-page .carousel-inner .container {
-  position: relative;
-  overflow: visible;
-}
-/* line 255, ../../sass/_landing.sass */
-.landing-page .carousel-inner {
-  overflow: visible;
-}
-/* line 258, ../../sass/_landing.sass */
-.landing-page .carousel-caption {
-  position: absolute;
-  top: 100px;
-  left: 0;
-  bottom: auto;
-  right: auto;
-  text-align: left;
-}
-/* line 266, ../../sass/_landing.sass */
-.landing-page .carousel-caption {
-  position: absolute;
-  top: 100px;
-  left: 0;
-  bottom: auto;
-  right: auto;
-  text-align: left;
-}
-/* line 274, ../../sass/_landing.sass */
-.landing-page .carousel-caption.blank {
-  top: 140px;
-}
-/* line 277, ../../sass/_landing.sass */
-.landing-page .carousel-image {
-  position: absolute;
-  right: 10px;
-  top: 150px;
-}
-/* line 282, ../../sass/_landing.sass */
-.landing-page .carousel-indicators {
-  padding-right: 60px;
-}
-/* line 285, ../../sass/_landing.sass */
-.landing-page .carousel-caption h1 {
-  font-weight: 700;
-  font-size: 38px;
-  text-transform: uppercase;
-  text-shadow: none;
-  letter-spacing: -1.5px;
-}
-/* line 292, ../../sass/_landing.sass */
-.landing-page .carousel-caption p {
-  font-weight: 700;
-  text-transform: uppercase;
-  text-shadow: none;
-}
-/* line 297, ../../sass/_landing.sass */
-.landing-page .caption-link {
-  color: #fff;
-  margin-left: 10px;
-  text-transform: capitalize;
-  font-weight: 400;
-}
-/* line 303, ../../sass/_landing.sass */
-.landing-page .caption-link:hover {
-  text-decoration: none;
-  color: inherit;
-}
-/* line 307, ../../sass/_landing.sass */
-.landing-page .services {
-  padding-top: 60px;
-}
-/* line 310, ../../sass/_landing.sass */
-.landing-page .services h2 {
-  font-size: 20px;
-  letter-spacing: -1px;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-/* line 316, ../../sass/_landing.sass */
-.landing-page .features-block {
-  margin-top: 40px;
-}
-/* line 319, ../../sass/_landing.sass */
-.landing-page .features-text {
-  margin-top: 40px;
-}
-/* line 322, ../../sass/_landing.sass */
-.landing-page .features small {
-  color: #1ab394;
-}
-/* line 325, ../../sass/_landing.sass */
-.landing-page .features h2 {
-  font-size: 18px;
-  margin-top: 5px;
-}
-/* line 329, ../../sass/_landing.sass */
-.landing-page .features-text-alone {
-  margin: 40px 0;
-}
-/* line 332, ../../sass/_landing.sass */
-.landing-page .features-text-alone h1 {
-  font-weight: 200;
-}
-/* line 335, ../../sass/_landing.sass */
-.landing-page .features-icon {
-  color: #1ab394;
-  font-size: 40px;
-}
-/* line 339, ../../sass/_landing.sass */
-.landing-page .navy-section {
-  margin-top: 60px;
-  background: #1ab394;
-  color: #fff;
-  padding: 20px 0;
-}
-/* line 345, ../../sass/_landing.sass */
-.landing-page .gray-section {
-  background: #f4f4f4;
-  margin-top: 60px;
-}
-/* line 349, ../../sass/_landing.sass */
-.landing-page .team-member {
-  text-align: center;
-}
-/* line 352, ../../sass/_landing.sass */
-.landing-page .team-member img {
-  margin: auto;
-}
-/* line 355, ../../sass/_landing.sass */
-.landing-page .social-icon a {
-  background: #1ab394;
-  color: #fff;
-  padding: 4px 8px;
-  height: 28px;
-  width: 28px;
-  display: block;
-  border-radius: 50px;
-}
-/* line 364, ../../sass/_landing.sass */
-.landing-page .social-icon a:hover {
-  background: #179d82;
-}
-/* line 367, ../../sass/_landing.sass */
-.landing-page .img-small {
-  height: 88px;
-  width: 88px;
-}
-/* line 371, ../../sass/_landing.sass */
-.landing-page .pricing-plan {
-  margin: 20px 30px 0 30px;
-  border-radius: 4px;
-}
-/* line 375, ../../sass/_landing.sass */
-.landing-page .pricing-plan.selected {
-  transform: scale(1.1);
-  background: #f4f4f4;
-}
-/* line 379, ../../sass/_landing.sass */
-.landing-page .pricing-plan li {
-  padding: 10px 16px;
-  border-top: 1px solid #e7eaec;
-  text-align: center;
-  color: #aeaeae;
-}
-/* line 385, ../../sass/_landing.sass */
-.landing-page .pricing-plan .pricing-price span {
-  font-weight: 700;
-  color: #1ab394;
-}
-/* line 389, ../../sass/_landing.sass */
-.landing-page li.pricing-desc {
-  font-size: 13px;
-  border-top: none;
-  padding: 20px 16px;
-}
-/* line 394, ../../sass/_landing.sass */
-.landing-page li.pricing-title {
-  background: #1ab394;
-  color: #fff;
-  padding: 10px;
-  border-radius: 4px 4px 0 0;
-  font-size: 22px;
-  font-weight: 600;
-}
-/* line 402, ../../sass/_landing.sass */
-.landing-page .testimonials {
-  padding-top: 80px;
-  padding-bottom: 90px;
-  background-color: #1ab394;
-  background-image: url("../img/landing/avatar_all.png");
-}
-/* line 408, ../../sass/_landing.sass */
-.landing-page .big-icon {
-  font-size: 56px !important;
-}
-/* line 411, ../../sass/_landing.sass */
-.landing-page .features .big-icon {
-  color: #1ab394 !important;
-}
-/* line 414, ../../sass/_landing.sass */
-.landing-page .contact {
-  background-image: url("../img/landing/word_map.png");
-  background-position: 50% 50%;
-  background-repeat: no-repeat;
-  margin-top: 60px;
-}
-/* line 421, ../../sass/_landing.sass */
-.landing-page section.timeline {
-  padding-bottom: 30px;
-}
-/* line 424, ../../sass/_landing.sass */
-.landing-page section.comments {
-  padding-bottom: 80px;
-}
-/* line 428, ../../sass/_landing.sass */
-.landing-page .comments-avatar {
-  margin-top: 25px;
-  margin-left: 22px;
-  margin-bottom: 25px;
-}
-/* line 434, ../../sass/_landing.sass */
-.landing-page .comments-avatar .commens-name {
-  font-weight: 600;
-  font-size: 14px;
-}
-/* line 439, ../../sass/_landing.sass */
-.landing-page .comments-avatar img {
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  margin-right: 10px;
-}
-/* line 446, ../../sass/_landing.sass */
-.landing-page .bubble {
-  position: relative;
-  height: 120px;
-  padding: 20px;
-  background: #FFFFFF;
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  border-radius: 10px;
-  font-style: italic;
-  font-size: 14px;
-}
-/* line 458, ../../sass/_landing.sass */
-.landing-page .bubble:after {
-  content: "";
-  position: absolute;
-  border-style: solid;
-  border-width: 15px 14px 0;
-  border-color: #FFFFFF transparent;
-  display: block;
-  width: 0;
-  z-index: 1;
-  bottom: -15px;
-  left: 30px;
-}
-/* line 471, ../../sass/_landing.sass */
-.landing-page .btn-primary.btn-outline:hover,
-.landing-page .btn-success.btn-outline:hover,
-.landing-page .btn-info.btn-outline:hover,
-.landing-page .btn-warning.btn-outline:hover,
-.landing-page .btn-danger.btn-outline:hover {
-  color: #fff;
-}
-/* line 478, ../../sass/_landing.sass */
-.landing-page .btn-primary {
-  background-color: #1ab394;
-  border-color: #1ab394;
-  color: #FFFFFF;
-  font-size: 14px;
-  padding: 10px 20px;
-  font-weight: 600;
-}
-/* line 486, ../../sass/_landing.sass */
-.landing-page .btn-primary:hover,
-.landing-page .btn-primary:focus,
-.landing-page .btn-primary:active,
-.landing-page .btn-primary.active,
-.landing-page .open .dropdown-toggle.btn-primary {
-  background-color: #179d82;
-  border-color: #179d82;
-  color: #FFFFFF;
-}
-/* line 495, ../../sass/_landing.sass */
-.landing-page .btn-primary:active,
-.landing-page .btn-primary.active,
-.landing-page .open .dropdown-toggle.btn-primary {
-  background-image: none;
-}
-/* line 500, ../../sass/_landing.sass */
-.landing-page .btn-primary.disabled,
-.landing-page .btn-primary.disabled:hover,
-.landing-page .btn-primary.disabled:focus,
-.landing-page .btn-primary.disabled:active,
-.landing-page .btn-primary.disabled.active,
-.landing-page .btn-primary[disabled],
-.landing-page .btn-primary[disabled]:hover,
-.landing-page .btn-primary[disabled]:focus,
-.landing-page .btn-primary[disabled]:active,
-.landing-page .btn-primary.active[disabled],
-.landing-page fieldset[disabled] .btn-primary,
-.landing-page fieldset[disabled] .btn-primary:hover,
-.landing-page fieldset[disabled] .btn-primary:focus,
-.landing-page fieldset[disabled] .btn-primary:active,
-.landing-page fieldset[disabled] .btn-primary.active {
-  background-color: #1dc5a3;
-  border-color: #1dc5a3;
-}
-/* line 519, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper {
-  margin-top: 20px;
-}
-/* line 523, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper .container {
-  padding-right: 15px;
-  padding-left: 15px;
-}
-/* line 528, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper .navbar {
-  padding-right: 0;
-  padding-left: 0;
-}
-/* line 534, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper .navbar {
-  border-radius: 4px;
-}
-/* line 539, ../../sass/_landing.sass */
-.landing-page .carousel-caption p {
-  margin-bottom: 20px;
-  font-size: 14px;
-  line-height: 1.4;
-}
-/* line 545, ../../sass/_landing.sass */
-.landing-page .featurette-heading {
-  font-size: 50px;
-}
-/* line 550, ../../sass/_landing.sass */
-.landing-page .carousel-image {
-  display: none;
-}
-/* line 555, ../../sass/_landing.sass */
-.landing-page .carousel-caption,
-.landing-page .carousel-caption.blank {
-  left: 5%;
-  top: 80px;
-}
-/* line 561, ../../sass/_landing.sass */
-.landing-page .carousel-caption h1 {
-  font-size: 28px;
-}
-/* line 565, ../../sass/_landing.sass */
-.landing-page .navbar.navbar-scroll .navbar-brand {
-  margin-top: 6px;
-}
-/* line 569, ../../sass/_landing.sass */
-.landing-page .navbar-default {
-  background-color: #fff;
-  border-color: #fff;
-  padding: 15px 0;
-}
-/* line 575, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-nav > .active > a:focus {
-  background: transparent;
-  color: inherit;
-}
-/* line 580, ../../sass/_landing.sass */
-.landing-page .navbar-default .nav li a {
-  color: #676a6c;
-}
-/* line 584, ../../sass/_landing.sass */
-.landing-page .navbar-default .nav li a:hover {
-  color: #1ab394;
-}
-/* line 588, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper .navbar {
-  padding-top: 0;
-  padding-bottom: 5px;
-  border-bottom: 1px solid #e7eaec;
-  border-radius: 0;
-}
-/* line 595, ../../sass/_landing.sass */
-.landing-page .nav > li > a {
-  padding: 25px 10px 15px 10px;
-}
-/* line 599, ../../sass/_landing.sass */
-.landing-page .navbar-nav > li > a {
-  padding: 20px 10px;
-}
-/* line 603, ../../sass/_landing.sass */
-.landing-page .navbar .navbar-brand {
-  margin-top: 6px;
-  border-radius: 5px;
-  font-size: 12px;
-  padding: 10px;
-  height: auto;
-}
-/* line 611, ../../sass/_landing.sass */
-.landing-page .navbar-wrapper .navbar {
-  padding-left: 15px;
-  padding-right: 5px;
-}
-/* line 616, ../../sass/_landing.sass */
-.landing-page .navbar-default .navbar-nav > .active > a,
-.landing-page .navbar-default .navbar-nav > .active > a:hover {
-  color: inherit;
-}
-/* line 621, ../../sass/_landing.sass */
-.landing-page .carousel-control {
-  display: none;
-}
-/* line 626, ../../sass/_landing.sass */
-.landing-page .featurette-heading {
-  margin-top: 120px;
-}
-/* line 632, ../../sass/_landing.sass */
-.landing-page .navbar .navbar-header {
-  display: block;
-  float: none;
-}
-/* line 636, ../../sass/_landing.sass */
-.landing-page .navbar .navbar-header .navbar-toggle {
-  background-color: #ffffff;
-  padding: 9px 10px;
-  border: none;
-}
+  /* Bump up size of carousel content */ }
+  .landing-page .container {
+    overflow: hidden; }
+  .landing-page span.navy {
+    color: #1ab394; }
+  .landing-page p.text-color {
+    color: #676a6c; }
+  .landing-page a.navy-link {
+    color: #1ab394;
+    text-decoration: none; }
+  .landing-page a.navy-link:hover {
+    color: #179d82; }
+  .landing-page section p {
+    color: #aeaeae;
+    font-size: 13px; }
+  .landing-page address {
+    font-size: 13px; }
+  .landing-page h1 {
+    margin-top: 10px;
+    font-size: 30px;
+    font-weight: 200; }
+  .landing-page .navy-line {
+    width: 60px;
+    height: 1px;
+    margin: 60px auto 0;
+    border-bottom: 2px solid #1ab394; }
+  .landing-page .navbar-wrapper {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 200; }
+  .landing-page .navbar-wrapper > .container {
+    padding-right: 0;
+    padding-left: 0; }
+  .landing-page .navbar-wrapper .navbar {
+    padding-right: 15px;
+    padding-left: 15px; }
+  .landing-page .navbar-default.navbar-scroll {
+    background-color: #fff;
+    border-color: #fff;
+    padding: 15px 0; }
+  .landing-page .navbar-default {
+    background-color: transparent;
+    border-color: transparent;
+    transition: all 0.3s ease-in-out 0s; }
+  .landing-page .navbar-default .nav li a {
+    color: #fff;
+    font-family: "Open Sans", helvetica, arial, sans-serif;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    font-size: 14px; }
+  .landing-page .navbar-nav > li > a {
+    padding-top: 25px;
+    border-top: 6px solid transparent; }
+  .landing-page .navbar-default .navbar-nav > .active > a,
+  .landing-page .navbar-default .navbar-nav > .active > a:hover {
+    background: transparent;
+    color: #fff;
+    border-top: 6px solid #1ab394; }
+  .landing-page .navbar-default .navbar-nav > li > a:hover,
+  .landing-page .navbar-default .navbar-nav > li > a:focus {
+    color: #1ab394;
+    background: inherit; }
+  .landing-page .navbar-default .navbar-nav > .active > a:focus {
+    background: transparent;
+    color: #fff; }
+  .landing-page .navbar-default .navbar-nav > .active > a:focus {
+    background: transparent;
+    color: #ffffff; }
+  .landing-page .navbar-default.navbar-scroll .navbar-nav > .active > a:focus {
+    background: transparent;
+    color: inherit; }
+  .landing-page .navbar-default .navbar-brand:hover,
+  .landing-page .navbar-default .navbar-brand:focus {
+    background: #179d82;
+    color: #fff; }
+  .landing-page .navbar-default .navbar-brand {
+    color: #fff;
+    height: auto;
+    display: block;
+    font-size: 14px;
+    background: #1ab394;
+    padding: 15px 20px 15px 20px;
+    border-radius: 0 0 5px 5px;
+    font-weight: 700;
+    transition: all 0.3s ease-in-out 0s; }
+  .landing-page .navbar-scroll.navbar-default .nav li a {
+    color: #676a6c; }
+  .landing-page .navbar-scroll.navbar-default .nav li a:hover {
+    color: #1ab394; }
+  .landing-page .navbar-wrapper .navbar.navbar-scroll {
+    padding-top: 0;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #e7eaec;
+    border-radius: 0; }
+  .landing-page .nav > li.active {
+    border: none;
+    background: inherit; }
+  .landing-page .nav > li > a {
+    padding: 25px 10px 15px 10px; }
+  .landing-page .navbar-scroll .navbar-nav > li > a {
+    padding: 20px 10px; }
+  .landing-page .navbar-default .navbar-nav > .active > a,
+  .landing-page .navbar-default .navbar-nav > .active > a:hover {
+    border-top: 6px solid #1ab394; }
+  .landing-page .navbar-fixed-top {
+    border: none !important; }
+  .landing-page .navbar-fixed-top.navbar-scroll {
+    border-bottom: 1px solid #e7eaec !important; }
+  .landing-page .navbar.navbar-scroll .navbar-brand {
+    margin-top: 15px;
+    border-radius: 5px;
+    font-size: 12px;
+    padding: 10px;
+    height: auto; }
+  .landing-page .header-back {
+    height: 470px;
+    width: 100%; }
+  .landing-page .header-back.one {
+    background: url("../img/landing/header_one.jpg") 50% 0 no-repeat; }
+  .landing-page .header-back.two {
+    background: url("../img/landing/header_two.jpg") 50% 0 no-repeat; }
+  .landing-page .carousel {
+    height: 470px; }
+  .landing-page .carousel-caption {
+    z-index: 10; }
+  .landing-page .carousel .item {
+    height: 470px;
+    background-color: #777; }
+  .landing-page .carousel-inner > .item > img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    min-width: 100%;
+    height: 470px; }
+  .landing-page .carousel-fade .carousel-inner .item {
+    opacity: 0;
+    -webkit-transition-property: opacity;
+    transition-property: opacity; }
+  .landing-page .carousel-fade .carousel-inner .active {
+    opacity: 1; }
+  .landing-page .carousel-fade .carousel-inner .active.left,
+  .landing-page .carousel-fade .carousel-inner .active.right {
+    left: 0;
+    opacity: 0;
+    z-index: 1; }
+  .landing-page .carousel-fade .carousel-inner .next.left,
+  .landing-page .carousel-fade .carousel-inner .prev.right {
+    opacity: 1; }
+  .landing-page .carousel-fade .carousel-control {
+    z-index: 2; }
+  .landing-page .carousel-control.left,
+  .landing-page .carousel-control.right {
+    background: none; }
+  .landing-page .carousel-control {
+    width: 6%; }
+  .landing-page .carousel-inner .container {
+    position: relative;
+    overflow: visible; }
+  .landing-page .carousel-inner {
+    overflow: visible; }
+  .landing-page .carousel-caption {
+    position: absolute;
+    top: 100px;
+    left: 0;
+    bottom: auto;
+    right: auto;
+    text-align: left; }
+  .landing-page .carousel-caption {
+    position: absolute;
+    top: 100px;
+    left: 0;
+    bottom: auto;
+    right: auto;
+    text-align: left; }
+  .landing-page .carousel-caption.blank {
+    top: 140px; }
+  .landing-page .carousel-image {
+    position: absolute;
+    right: 10px;
+    top: 150px; }
+  .landing-page .carousel-indicators {
+    padding-right: 60px; }
+  .landing-page .carousel-caption h1 {
+    font-weight: 700;
+    font-size: 38px;
+    text-transform: uppercase;
+    text-shadow: none;
+    letter-spacing: -1.5px; }
+  .landing-page .carousel-caption p {
+    font-weight: 700;
+    text-transform: uppercase;
+    text-shadow: none; }
+  .landing-page .caption-link {
+    color: #fff;
+    margin-left: 10px;
+    text-transform: capitalize;
+    font-weight: 400; }
+  .landing-page .caption-link:hover {
+    text-decoration: none;
+    color: inherit; }
+  .landing-page .services {
+    padding-top: 60px; }
+  .landing-page .services h2 {
+    font-size: 20px;
+    letter-spacing: -1px;
+    font-weight: 600;
+    text-transform: uppercase; }
+  .landing-page .features-block {
+    margin-top: 40px; }
+  .landing-page .features-text {
+    margin-top: 40px; }
+  .landing-page .features small {
+    color: #1ab394; }
+  .landing-page .features h2 {
+    font-size: 18px;
+    margin-top: 5px; }
+  .landing-page .features-text-alone {
+    margin: 40px 0; }
+  .landing-page .features-text-alone h1 {
+    font-weight: 200; }
+  .landing-page .features-icon {
+    color: #1ab394;
+    font-size: 40px; }
+  .landing-page .navy-section {
+    margin-top: 60px;
+    background: #1ab394;
+    color: #fff;
+    padding: 20px 0; }
+  .landing-page .gray-section {
+    background: #f4f4f4;
+    margin-top: 60px; }
+  .landing-page .team-member {
+    text-align: center; }
+  .landing-page .team-member img {
+    margin: auto; }
+  .landing-page .social-icon a {
+    background: #1ab394;
+    color: #fff;
+    padding: 4px 8px;
+    height: 28px;
+    width: 28px;
+    display: block;
+    border-radius: 50px; }
+  .landing-page .social-icon a:hover {
+    background: #179d82; }
+  .landing-page .img-small {
+    height: 88px;
+    width: 88px; }
+  .landing-page .pricing-plan {
+    margin: 20px 30px 0 30px;
+    border-radius: 4px; }
+  .landing-page .pricing-plan.selected {
+    transform: scale(1.1);
+    background: #f4f4f4; }
+  .landing-page .pricing-plan li {
+    padding: 10px 16px;
+    border-top: 1px solid #e7eaec;
+    text-align: center;
+    color: #aeaeae; }
+  .landing-page .pricing-plan .pricing-price span {
+    font-weight: 700;
+    color: #1ab394; }
+  .landing-page li.pricing-desc {
+    font-size: 13px;
+    border-top: none;
+    padding: 20px 16px; }
+  .landing-page li.pricing-title {
+    background: #1ab394;
+    color: #fff;
+    padding: 10px;
+    border-radius: 4px 4px 0 0;
+    font-size: 22px;
+    font-weight: 600; }
+  .landing-page .testimonials {
+    padding-top: 80px;
+    padding-bottom: 90px;
+    background-color: #1ab394;
+    background-image: url("../img/landing/avatar_all.png"); }
+  .landing-page .big-icon {
+    font-size: 56px !important; }
+  .landing-page .features .big-icon {
+    color: #1ab394 !important; }
+  .landing-page .contact {
+    background-image: url("../img/landing/word_map.png");
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    margin-top: 60px; }
+  .landing-page section.timeline {
+    padding-bottom: 30px; }
+  .landing-page section.comments {
+    padding-bottom: 80px; }
+  .landing-page .comments-avatar {
+    margin-top: 25px;
+    margin-left: 22px;
+    margin-bottom: 25px; }
+  .landing-page .comments-avatar .commens-name {
+    font-weight: 600;
+    font-size: 14px; }
+  .landing-page .comments-avatar img {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    margin-right: 10px; }
+  .landing-page .bubble {
+    position: relative;
+    height: 120px;
+    padding: 20px;
+    background: #FFFFFF;
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+    font-style: italic;
+    font-size: 14px; }
+  .landing-page .bubble:after {
+    content: "";
+    position: absolute;
+    border-style: solid;
+    border-width: 15px 14px 0;
+    border-color: #FFFFFF transparent;
+    display: block;
+    width: 0;
+    z-index: 1;
+    bottom: -15px;
+    left: 30px; }
+  .landing-page .btn-primary.btn-outline:hover,
+  .landing-page .btn-success.btn-outline:hover,
+  .landing-page .btn-info.btn-outline:hover,
+  .landing-page .btn-warning.btn-outline:hover,
+  .landing-page .btn-danger.btn-outline:hover {
+    color: #fff; }
+  .landing-page .btn-primary {
+    background-color: #1ab394;
+    border-color: #1ab394;
+    color: #FFFFFF;
+    font-size: 14px;
+    padding: 10px 20px;
+    font-weight: 600; }
+  .landing-page .btn-primary:hover,
+  .landing-page .btn-primary:focus,
+  .landing-page .btn-primary:active,
+  .landing-page .btn-primary.active,
+  .landing-page .open .dropdown-toggle.btn-primary {
+    background-color: #179d82;
+    border-color: #179d82;
+    color: #FFFFFF; }
+  .landing-page .btn-primary:active,
+  .landing-page .btn-primary.active,
+  .landing-page .open .dropdown-toggle.btn-primary {
+    background-image: none; }
+  .landing-page .btn-primary.disabled,
+  .landing-page .btn-primary.disabled:hover,
+  .landing-page .btn-primary.disabled:focus,
+  .landing-page .btn-primary.disabled:active,
+  .landing-page .btn-primary.disabled.active,
+  .landing-page .btn-primary[disabled],
+  .landing-page .btn-primary[disabled]:hover,
+  .landing-page .btn-primary[disabled]:focus,
+  .landing-page .btn-primary[disabled]:active,
+  .landing-page .btn-primary.active[disabled],
+  .landing-page fieldset[disabled] .btn-primary,
+  .landing-page fieldset[disabled] .btn-primary:hover,
+  .landing-page fieldset[disabled] .btn-primary:focus,
+  .landing-page fieldset[disabled] .btn-primary:active,
+  .landing-page fieldset[disabled] .btn-primary.active {
+    background-color: #1dc5a3;
+    border-color: #1dc5a3; }
+  .landing-page .navbar-wrapper {
+    margin-top: 20px; }
+  .landing-page .navbar-wrapper .container {
+    padding-right: 15px;
+    padding-left: 15px; }
+  .landing-page .navbar-wrapper .navbar {
+    padding-right: 0;
+    padding-left: 0; }
+  .landing-page .navbar-wrapper .navbar {
+    border-radius: 4px; }
+  .landing-page .carousel-caption p {
+    margin-bottom: 20px;
+    font-size: 14px;
+    line-height: 1.4; }
+  .landing-page .featurette-heading {
+    font-size: 50px; }
+  .landing-page .carousel-image {
+    display: none; }
+  .landing-page .carousel-caption,
+  .landing-page .carousel-caption.blank {
+    left: 5%;
+    top: 80px; }
+  .landing-page .carousel-caption h1 {
+    font-size: 28px; }
+  .landing-page .navbar.navbar-scroll .navbar-brand {
+    margin-top: 6px; }
+  .landing-page .navbar-default {
+    background-color: #fff;
+    border-color: #fff;
+    padding: 15px 0; }
+  .landing-page .navbar-default .navbar-nav > .active > a:focus {
+    background: transparent;
+    color: inherit; }
+  .landing-page .navbar-default .nav li a {
+    color: #676a6c; }
+  .landing-page .navbar-default .nav li a:hover {
+    color: #1ab394; }
+  .landing-page .navbar-wrapper .navbar {
+    padding-top: 0;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #e7eaec;
+    border-radius: 0; }
+  .landing-page .nav > li > a {
+    padding: 25px 10px 15px 10px; }
+  .landing-page .navbar-nav > li > a {
+    padding: 20px 10px; }
+  .landing-page .navbar .navbar-brand {
+    margin-top: 6px;
+    border-radius: 5px;
+    font-size: 12px;
+    padding: 10px;
+    height: auto; }
+  .landing-page .navbar-wrapper .navbar {
+    padding-left: 15px;
+    padding-right: 5px; }
+  .landing-page .navbar-default .navbar-nav > .active > a,
+  .landing-page .navbar-default .navbar-nav > .active > a:hover {
+    color: inherit; }
+  .landing-page .carousel-control {
+    display: none; }
+  .landing-page .featurette-heading {
+    margin-top: 120px; }
+  .landing-page .navbar .navbar-header {
+    display: block;
+    float: none; }
+  .landing-page .navbar .navbar-header .navbar-toggle {
+    background-color: #ffffff;
+    padding: 9px 10px;
+    border: none; }
 
-/* line 2, ../../sass/_rtl.sass */
 body.rtls {
-  /* Theme config */
-}
-/* line 4, ../../sass/_rtl.sass */
-body.rtls #page-wrapper {
-  margin: 0 220px 0 0;
-}
-/* line 8, ../../sass/_rtl.sass */
-body.rtls .nav-second-level li a {
-  padding: 7px 35px 7px 10px;
-}
-/* line 12, ../../sass/_rtl.sass */
-body.rtls .ibox-title h5 {
-  float: right;
-}
-/* line 16, ../../sass/_rtl.sass */
-body.rtls .pull-right {
-  float: left !important;
-}
-/* line 20, ../../sass/_rtl.sass */
-body.rtls .pull-left {
-  float: right !important;
-}
-/* line 24, ../../sass/_rtl.sass */
-body.rtls .ibox-tools {
-  float: left;
-}
-/* line 28, ../../sass/_rtl.sass */
-body.rtls .stat-percent {
-  float: left;
-}
-/* line 32, ../../sass/_rtl.sass */
-body.rtls .navbar-right {
-  float: left !important;
-}
-/* line 36, ../../sass/_rtl.sass */
-body.rtls .navbar-top-links li:last-child {
-  margin-left: 40px;
-  margin-right: 0;
-}
-/* line 41, ../../sass/_rtl.sass */
-body.rtls .minimalize-styl-2 {
-  float: right;
-  margin: 14px 20px 5px 5px;
-}
-/* line 46, ../../sass/_rtl.sass */
-body.rtls .feed-element > .pull-left {
-  margin-left: 10px;
-  margin-right: 0;
-}
-/* line 51, ../../sass/_rtl.sass */
-body.rtls .timeline-item .date {
-  text-align: left;
-}
-/* line 55, ../../sass/_rtl.sass */
-body.rtls .timeline-item .date i {
-  left: 0;
-  right: auto;
-}
-/* line 60, ../../sass/_rtl.sass */
-body.rtls .timeline-item .content {
-  border-right: 1px solid #e7eaec;
-  border-left: none;
-}
-/* line 65, ../../sass/_rtl.sass */
-body.rtls .theme-config {
-  left: 0;
-  right: auto;
-}
-/* line 70, ../../sass/_rtl.sass */
-body.rtls .spin-icon {
-  border-radius: 0 20px 20px 0;
-}
-/* line 74, ../../sass/_rtl.sass */
-body.rtls .toast-close-button {
-  float: left;
-}
-/* line 78, ../../sass/_rtl.sass */
-body.rtls #toast-container > .toast:before {
-  margin: auto -1.5em auto 0.5em;
-}
-/* line 82, ../../sass/_rtl.sass */
-body.rtls #toast-container > div {
-  padding: 15px 50px 15px 15px;
-}
-/* line 86, ../../sass/_rtl.sass */
-body.rtls .center-orientation .vertical-timeline-icon i {
-  margin-left: 0;
-  margin-right: -12px;
-}
-/* line 91, ../../sass/_rtl.sass */
-body.rtls .vertical-timeline-icon i {
-  right: 50%;
-  left: auto;
-  margin-left: auto;
-  margin-right: -12px;
-}
-/* line 98, ../../sass/_rtl.sass */
-body.rtls .file-box {
-  float: right;
-}
-/* line 102, ../../sass/_rtl.sass */
-body.rtls ul.notes li {
-  float: right;
-}
-/* line 106, ../../sass/_rtl.sass */
-body.rtls .chat-users, body.rtls .chat-statistic {
-  margin-right: -30px;
-  margin-left: auto;
-}
-/* line 111, ../../sass/_rtl.sass */
-body.rtls .dropdown-menu > li > a {
-  text-align: right;
-}
-/* line 115, ../../sass/_rtl.sass */
-body.rtls .b-r {
-  border-left: 1px solid #e7eaec;
-  border-right: none;
-}
-/* line 120, ../../sass/_rtl.sass */
-body.rtls .dd-list .dd-list {
-  padding-right: 30px;
-  padding-left: 0;
-}
-/* line 125, ../../sass/_rtl.sass */
-body.rtls .dd-item > button {
-  float: right;
-}
-/* line 130, ../../sass/_rtl.sass */
-body.rtls .theme-config-box {
-  margin-left: -220px;
-  margin-right: 0;
-}
-/* line 135, ../../sass/_rtl.sass */
-body.rtls .theme-config-box.show {
-  margin-left: 0;
-  margin-right: 0;
-}
-/* line 140, ../../sass/_rtl.sass */
-body.rtls .spin-icon {
-  right: 0;
-  left: auto;
-}
-/* line 145, ../../sass/_rtl.sass */
-body.rtls .skin-settings {
-  margin-right: 40px;
-  margin-left: 0;
-}
-/* line 150, ../../sass/_rtl.sass */
-body.rtls .skin-settings {
-  direction: ltr;
-}
-/* line 154, ../../sass/_rtl.sass */
-body.rtls .footer.fixed {
-  margin-right: 220px;
-  margin-left: 0;
-}
+  /* Theme config */ }
+  body.rtls #page-wrapper {
+    margin: 0 220px 0 0; }
+  body.rtls .nav-second-level li a {
+    padding: 7px 35px 7px 10px; }
+  body.rtls .ibox-title h5 {
+    float: right; }
+  body.rtls .pull-right {
+    float: left !important; }
+  body.rtls .pull-left {
+    float: right !important; }
+  body.rtls .ibox-tools {
+    float: left; }
+  body.rtls .stat-percent {
+    float: left; }
+  body.rtls .navbar-right {
+    float: left !important; }
+  body.rtls .navbar-top-links li:last-child {
+    margin-left: 40px;
+    margin-right: 0; }
+  body.rtls .minimalize-styl-2 {
+    float: right;
+    margin: 14px 20px 5px 5px; }
+  body.rtls .feed-element > .pull-left {
+    margin-left: 10px;
+    margin-right: 0; }
+  body.rtls .timeline-item .date {
+    text-align: left; }
+  body.rtls .timeline-item .date i {
+    left: 0;
+    right: auto; }
+  body.rtls .timeline-item .content {
+    border-right: 1px solid #e7eaec;
+    border-left: none; }
+  body.rtls .theme-config {
+    left: 0;
+    right: auto; }
+  body.rtls .spin-icon {
+    border-radius: 0 20px 20px 0; }
+  body.rtls .toast-close-button {
+    float: left; }
+  body.rtls #toast-container > .toast:before {
+    margin: auto -1.5em auto 0.5em; }
+  body.rtls #toast-container > div {
+    padding: 15px 50px 15px 15px; }
+  body.rtls .center-orientation .vertical-timeline-icon i {
+    margin-left: 0;
+    margin-right: -12px; }
+  body.rtls .vertical-timeline-icon i {
+    right: 50%;
+    left: auto;
+    margin-left: auto;
+    margin-right: -12px; }
+  body.rtls .file-box {
+    float: right; }
+  body.rtls ul.notes li {
+    float: right; }
+  body.rtls .chat-users, body.rtls .chat-statistic {
+    margin-right: -30px;
+    margin-left: auto; }
+  body.rtls .dropdown-menu > li > a {
+    text-align: right; }
+  body.rtls .b-r {
+    border-left: 1px solid #e7eaec;
+    border-right: none; }
+  body.rtls .dd-list .dd-list {
+    padding-right: 30px;
+    padding-left: 0; }
+  body.rtls .dd-item > button {
+    float: right; }
+  body.rtls .theme-config-box {
+    margin-left: -220px;
+    margin-right: 0; }
+  body.rtls .theme-config-box.show {
+    margin-left: 0;
+    margin-right: 0; }
+  body.rtls .spin-icon {
+    right: 0;
+    left: auto; }
+  body.rtls .skin-settings {
+    margin-right: 40px;
+    margin-left: 0; }
+  body.rtls .skin-settings {
+    direction: ltr; }
+  body.rtls .footer.fixed {
+    margin-right: 220px;
+    margin-left: 0; }
 
 @media (max-width: 992px) {
-  /* line 163, ../../sass/_rtl.sass */
   body.rtls .chat-users, body.rtls .chat-statistic {
-    margin-right: 0;
-  }
-}
-/* line 169, ../../sass/_rtl.sass */
+    margin-right: 0; } }
 body.rtls.mini-navbar .footer.fixed, body.body-small.mini-navbar .footer.fixed {
-  margin: 0 70px 0 0;
-}
+  margin: 0 70px 0 0; }
 
-/* line 173, ../../sass/_rtl.sass */
 body.rtls.mini-navbar.fixed-sidebar .footer.fixed, body.body-small.mini-navbar .footer.fixed {
-  margin: 0 0 0 0;
-}
+  margin: 0 0 0 0; }
 
-/* line 177, ../../sass/_rtl.sass */
 body.rtls.top-navigation .navbar-toggle {
   float: right;
   margin-left: 15px;
-  margin-right: 15px;
-}
+  margin-right: 15px; }
 
-/* line 183, ../../sass/_rtl.sass */
 .body-small.rtls.top-navigation .navbar-header {
-  float: none;
-}
+  float: none; }
 
-/* line 187, ../../sass/_rtl.sass */
 body.rtls.top-navigation #page-wrapper {
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 191, ../../sass/_rtl.sass */
 body.rtls.mini-navbar #page-wrapper {
-  margin: 0 70px 0 0;
-}
+  margin: 0 70px 0 0; }
 
-/* line 195, ../../sass/_rtl.sass */
 body.rtls.mini-navbar.fixed-sidebar #page-wrapper {
-  margin: 0 0 0 0;
-}
+  margin: 0 0 0 0; }
 
-/* line 199, ../../sass/_rtl.sass */
 body.rtls.body-small.fixed-sidebar.mini-navbar #page-wrapper {
-  margin: 0 220px 0 0;
-}
+  margin: 0 220px 0 0; }
 
-/* line 203, ../../sass/_rtl.sass */
 body.rtls.body-small.fixed-sidebar.mini-navbar .navbar-static-side {
-  width: 220px;
-}
+  width: 220px; }
 
-/* line 207, ../../sass/_rtl.sass */
 .body-small.rtls .navbar-fixed-top {
-  margin-right: 0;
-}
+  margin-right: 0; }
 
-/* line 211, ../../sass/_rtl.sass */
 .body-small.rtls .navbar-header {
-  float: right;
-}
+  float: right; }
 
-/* line 215, ../../sass/_rtl.sass */
 body.rtls .navbar-top-links li:last-child {
-  margin-left: 20px;
-}
+  margin-left: 20px; }
 
-/* line 219, ../../sass/_rtl.sass */
 body.rtls .top-navigation #page-wrapper, body.rtls.mini-navbar .top-navigation #page-wrapper, body.rtls.mini-navbar.top-navigation #page-wrapper {
-  margin: 0;
-}
+  margin: 0; }
 
-/* line 223, ../../sass/_rtl.sass */
 body.rtls .top-navigation .footer.fixed, body.rtls.top-navigation .footer.fixed {
-  margin: 0;
-}
+  margin: 0; }
 
 @media (max-width: 768px) {
-  /* line 229, ../../sass/_rtl.sass */
   body.rtls .navbar-top-links li:last-child {
-    margin-left: 20px;
-  }
+    margin-left: 20px; }
 
-  /* line 233, ../../sass/_rtl.sass */
   .body-small.rtls #page-wrapper {
     position: inherit;
     margin: 0 0 0 0;
-    min-height: 1000px;
-  }
+    min-height: 1000px; }
 
-  /* line 239, ../../sass/_rtl.sass */
   .body-small.rtls .navbar-static-side {
     display: none;
     z-index: 2001;
     position: absolute;
-    width: 70px;
-  }
+    width: 70px; }
 
-  /* line 246, ../../sass/_rtl.sass */
   .body-small.rtls.mini-navbar .navbar-static-side {
-    display: block;
-  }
+    display: block; }
 
-  /* line 250, ../../sass/_rtl.sass */
   .rtls.fixed-sidebar.body-small .navbar-static-side {
     display: none;
     z-index: 2001;
     position: fixed;
-    width: 220px;
-  }
+    width: 220px; }
 
-  /* line 257, ../../sass/_rtl.sass */
   .rtls.fixed-sidebar.body-small.mini-navbar .navbar-static-side {
-    display: block;
-  }
-}
-/* line 264, ../../sass/_rtl.sass */
+    display: block; } }
 .rtls .ltr-support {
-  direction: ltr;
-}
+  direction: ltr; }
 
-/* line 268, ../../sass/_rtl.sass */
 .rtls.mini-navbar .nav-second-level, .rtls.mini-navbar li.active .nav-second-level {
   left: auto;
-  right: 70px;
-}
+  right: 70px; }
 
-/* line 273, ../../sass/_rtl.sass */
 .rtls #right-sidebar {
   left: -260px;
-  right: auto;
-}
+  right: auto; }
 
-/* line 278, ../../sass/_rtl.sass */
 .rtls #right-sidebar.sidebar-open {
-  left: 0;
-}
+  left: 0; }
 
-/* line 1, ../../sass/_theme-config.sass */
 .theme-config {
   position: absolute;
   top: 90px;
   right: 0;
-  overflow: hidden;
-}
+  overflow: hidden; }
 
-/* line 8, ../../sass/_theme-config.sass */
 .theme-config-box {
   margin-right: -220px;
   position: relative;
   z-index: 2000;
-  transition-duration: 0.8s;
-}
+  transition-duration: 0.8s; }
 
-/* line 15, ../../sass/_theme-config.sass */
 .theme-config-box.show {
-  margin-right: 0;
-}
+  margin-right: 0; }
 
-/* line 19, ../../sass/_theme-config.sass */
 .spin-icon {
   background: #1ab394;
   position: absolute;
@@ -9963,17 +6821,13 @@ body.rtls .top-navigation .footer.fixed, body.rtls.top-navigation .footer.fixed 
   left: 0;
   width: 40px;
   color: #fff;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
-/* line 32, ../../sass/_theme-config.sass */
 .skin-settings {
   width: 220px;
   margin-left: 40px;
-  background: #f3f3f4;
-}
+  background: #f3f3f4; }
 
-/* line 38, ../../sass/_theme-config.sass */
 .skin-settings .title {
   background: #efefef;
   text-align: center;
@@ -9981,1130 +6835,698 @@ body.rtls .top-navigation .footer.fixed, body.rtls.top-navigation .footer.fixed 
   font-weight: 600;
   display: block;
   padding: 10px 15px;
-  font-size: 12px;
-}
+  font-size: 12px; }
 
-/* line 48, ../../sass/_theme-config.sass */
 .setings-item {
-  padding: 10px 30px;
-}
+  padding: 10px 30px; }
 
-/* line 52, ../../sass/_theme-config.sass */
 .setings-item.skin {
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 56, ../../sass/_theme-config.sass */
 .setings-item .switch {
-  float: right;
-}
+  float: right; }
 
-/* line 60, ../../sass/_theme-config.sass */
 .skin-name a {
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
-/* line 64, ../../sass/_theme-config.sass */
 .setings-item a {
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 68, ../../sass/_theme-config.sass */
 .default-skin, .blue-skin, .ultra-skin, .yellow-skin {
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 72, ../../sass/_theme-config.sass */
 .default-skin {
   font-weight: 600;
-  background: #283A49;
-}
+  background: #283A49; }
 
-/* line 77, ../../sass/_theme-config.sass */
 .default-skin:hover {
-  background: #1e2e3d;
-}
+  background: #1e2e3d; }
 
-/* line 81, ../../sass/_theme-config.sass */
 .blue-skin {
   font-weight: 600;
-  background: url("patterns/header-profile-skin-1.png") repeat scroll 0 0;
-}
+  background: url("patterns/header-profile-skin-1.png") repeat scroll 0 0; }
 
-/* line 86, ../../sass/_theme-config.sass */
 .blue-skin:hover {
-  background: #0d8ddb;
-}
+  background: #0d8ddb; }
 
-/* line 90, ../../sass/_theme-config.sass */
 .yellow-skin {
   font-weight: 600;
-  background: url("patterns/header-profile-skin-3.png") repeat scroll 0 100%;
-}
+  background: url("patterns/header-profile-skin-3.png") repeat scroll 0 100%; }
 
-/* line 95, ../../sass/_theme-config.sass */
 .yellow-skin:hover {
-  background: #ce8735;
-}
+  background: #ce8735; }
 
-/* line 99, ../../sass/_theme-config.sass */
 .ultra-skin {
   padding: 20px 10px;
   font-weight: 600;
-  background: url("patterns/3.png") repeat scroll 0 0;
-}
+  background: url("patterns/3.png") repeat scroll 0 0; }
 
-/* line 105, ../../sass/_theme-config.sass */
 .ultra-skin:hover {
-  background: url("patterns/4.png") repeat scroll 0 0;
-}
+  background: url("patterns/4.png") repeat scroll 0 0; }
 
 /* SKIN 1 - INSPINIA - Responsive Admin Theme NAME - Blue light */
-/* line 10, ../../sass/_skins.sass */
 .skin-1 .minimalize-styl-2 {
-  margin: 14px 5px 5px 30px;
-}
+  margin: 14px 5px 5px 30px; }
 
-/* line 14, ../../sass/_skins.sass */
 .skin-1 .navbar-top-links li:last-child {
-  margin-right: 30px;
-}
+  margin-right: 30px; }
 
-/* line 18, ../../sass/_skins.sass */
 .skin-1.fixed-nav .minimalize-styl-2 {
-  margin: 14px 5px 5px 15px;
-}
+  margin: 14px 5px 5px 15px; }
 
-/* line 22, ../../sass/_skins.sass */
 .skin-1 .spin-icon {
-  background: #0e9aef !important;
-}
+  background: #0e9aef !important; }
 
-/* line 26, ../../sass/_skins.sass */
 .skin-1 .nav-header {
   background-color: #0e9aef;
-  background-image: url("patterns/header-profile-skin-1.png");
-}
+  background-image: url("patterns/header-profile-skin-1.png"); }
 
-/* line 31, ../../sass/_skins.sass */
 .skin-1.mini-navbar .nav-second-level {
-  background: #3e495f;
-}
+  background: #3e495f; }
 
-/* line 35, ../../sass/_skins.sass */
 .skin-1 .breadcrumb {
-  background: transparent;
-}
+  background: transparent; }
 
-/* line 39, ../../sass/_skins.sass */
 .skin-1 .page-heading {
-  border: none;
-}
+  border: none; }
 
-/* line 43, ../../sass/_skins.sass */
 .skin-1 .nav > li.active {
-  background: #3a4459;
-}
+  background: #3a4459; }
 
-/* line 47, ../../sass/_skins.sass */
 .skin-1 .nav > li > a {
-  color: #9ea6b9;
-}
+  color: #9ea6b9; }
 
-/* line 50, ../../sass/_skins.sass */
 .skin-1 ul.nav-second-level {
-  background-color: inherit;
-}
+  background-color: inherit; }
 
-/* line 53, ../../sass/_skins.sass */
 .skin-1 .nav > li.active > a {
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 57, ../../sass/_skins.sass */
 .skin-1 .navbar-minimalize {
   background: #0e9aef;
-  border-color: #0e9aef;
-}
+  border-color: #0e9aef; }
 
-/* line 62, ../../sass/_skins.sass */
 body.skin-1 {
-  background: #3e495f;
-}
+  background: #3e495f; }
 
-/* line 66, ../../sass/_skins.sass */
 .skin-1 .navbar-static-top {
-  background: #ffffff;
-}
+  background: #ffffff; }
 
-/* line 70, ../../sass/_skins.sass */
 .skin-1 .dashboard-header {
   background: transparent;
   border-bottom: none !important;
   border-top: none;
-  padding: 20px 30px 10px 30px;
-}
+  padding: 20px 30px 10px 30px; }
 
-/* line 77, ../../sass/_skins.sass */
 .fixed-nav.skin-1 .navbar-fixed-top {
-  background: #fff;
-}
+  background: #fff; }
 
-/* line 81, ../../sass/_skins.sass */
 .skin-1 .wrapper-content {
-  padding: 30px 15px;
-}
+  padding: 30px 15px; }
 
-/* line 85, ../../sass/_skins.sass */
 .skin-1 #page-wrapper {
-  background: #f4f6fa;
-}
+  background: #f4f6fa; }
 
-/* line 89, ../../sass/_skins.sass */
 .skin-1 .ibox-title, .skin-1 .ibox-content {
-  border-width: 1px;
-}
+  border-width: 1px; }
 
-/* line 93, ../../sass/_skins.sass */
 .skin-1 .ibox-content:last-child {
-  border-style: solid solid solid solid;
-}
+  border-style: solid solid solid solid; }
 
-/* line 97, ../../sass/_skins.sass */
 .skin-1 .nav > li.active {
-  border: none;
-}
+  border: none; }
 
-/* line 101, ../../sass/_skins.sass */
 .skin-1 .nav-header {
-  padding: 35px 25px 25px 25px;
-}
+  padding: 35px 25px 25px 25px; }
 
-/* line 105, ../../sass/_skins.sass */
 .skin-1 .nav-header a.dropdown-toggle {
   color: #fff;
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 110, ../../sass/_skins.sass */
 .skin-1 .nav-header a.dropdown-toggle .text-muted {
   color: #fff;
-  opacity: 0.8;
-}
+  opacity: 0.8; }
 
-/* line 115, ../../sass/_skins.sass */
 .skin-1 .profile-element {
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 119, ../../sass/_skins.sass */
 .skin-1 .img-circle {
-  border-radius: 5px;
-}
+  border-radius: 5px; }
 
-/* line 123, ../../sass/_skins.sass */
 .skin-1 .navbar-default .nav > li > a:hover, .skin-1 .navbar-default .nav > li > a:focus {
   background: #3a4459;
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 128, ../../sass/_skins.sass */
 .skin-1 .nav.nav-tabs > li.active > a {
-  color: #555;
-}
+  color: #555; }
 
-/* line 132, ../../sass/_skins.sass */
 .skin-1 .nav.nav-tabs > li.active {
-  background: transparent;
-}
+  background: transparent; }
 
-/* line 143, ../../sass/_skins.sass */
 body.skin-2 {
-  color: #565758 !important;
-}
+  color: #565758 !important; }
 
-/* line 147, ../../sass/_skins.sass */
 .skin-2 .minimalize-styl-2 {
-  margin: 14px 5px 5px 25px;
-}
+  margin: 14px 5px 5px 25px; }
 
-/* line 151, ../../sass/_skins.sass */
 .skin-2 .navbar-top-links li:last-child {
-  margin-right: 25px;
-}
+  margin-right: 25px; }
 
-/* line 155, ../../sass/_skins.sass */
 .skin-2 .spin-icon {
-  background: #23c6c8 !important;
-}
+  background: #23c6c8 !important; }
 
-/* line 159, ../../sass/_skins.sass */
 .skin-2 .nav-header {
   background-color: #23c6c8;
-  background-image: url("patterns/header-profile-skin-2.png");
-}
+  background-image: url("patterns/header-profile-skin-2.png"); }
 
-/* line 164, ../../sass/_skins.sass */
 .skin-2.mini-navbar .nav-second-level {
-  background: #ededed;
-}
+  background: #ededed; }
 
-/* line 168, ../../sass/_skins.sass */
 .skin-2 .breadcrumb {
-  background: transparent;
-}
+  background: transparent; }
 
-/* line 172, ../../sass/_skins.sass */
 .skin-2.fixed-nav .minimalize-styl-2 {
-  margin: 14px 5px 5px 15px;
-}
+  margin: 14px 5px 5px 15px; }
 
-/* line 176, ../../sass/_skins.sass */
 .skin-2 .page-heading {
   border: none;
-  background: rgba(255, 255, 255, 0.7);
-}
+  background: rgba(255, 255, 255, 0.7); }
 
-/* line 180, ../../sass/_skins.sass */
 .skin-2 ul.nav-second-level {
-  background-color: inherit;
-}
+  background-color: inherit; }
 
-/* line 183, ../../sass/_skins.sass */
 .skin-2 .nav > li.active {
-  background: #e0e0e0;
-}
+  background: #e0e0e0; }
 
-/* line 187, ../../sass/_skins.sass */
 .skin-2 .logo-element {
-  padding: 17px 0;
-}
+  padding: 17px 0; }
 
-/* line 191, ../../sass/_skins.sass */
 .skin-2 .nav > li > a, .skin-2 .welcome-message {
-  color: #edf6ff;
-}
+  color: #edf6ff; }
 
-/* line 195, ../../sass/_skins.sass */
 .skin-2 #top-search::-moz-placeholder {
   color: #edf6ff;
-  opacity: 0.5;
-}
+  opacity: 0.5; }
 
-/* line 200, ../../sass/_skins.sass */
 .skin-2 #side-menu > li > a, .skin-2 .nav.nav-second-level > li > a {
-  color: #586b7d;
-}
+  color: #586b7d; }
 
-/* line 204, ../../sass/_skins.sass */
 .skin-2 .nav > li.active > a {
-  color: #213a53;
-}
+  color: #213a53; }
 
-/* line 208, ../../sass/_skins.sass */
 .skin-2.mini-navbar .nav-header {
-  background: #213a53;
-}
+  background: #213a53; }
 
-/* line 212, ../../sass/_skins.sass */
 .skin-2 .navbar-minimalize {
   background: #23c6c8;
-  border-color: #23c6c8;
-}
+  border-color: #23c6c8; }
 
-/* line 217, ../../sass/_skins.sass */
 .skin-2 .border-bottom {
-  border-bottom: none !important;
-}
+  border-bottom: none !important; }
 
-/* line 221, ../../sass/_skins.sass */
 .skin-2 #top-search {
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 225, ../../sass/_skins.sass */
 body.skin-2 #wrapper {
-  background-color: #ededed;
-}
+  background-color: #ededed; }
 
-/* line 229, ../../sass/_skins.sass */
 .skin-2 .navbar-static-top {
-  background: #213a53;
-}
+  background: #213a53; }
 
-/* line 233, ../../sass/_skins.sass */
 .fixed-nav.skin-2 .navbar-fixed-top {
   background: #213a53;
-  border-bottom: none !important;
-}
+  border-bottom: none !important; }
 
-/* line 238, ../../sass/_skins.sass */
 .skin-2 .nav-header {
-  padding: 30px 25px 30px 25px;
-}
+  padding: 30px 25px 30px 25px; }
 
-/* line 242, ../../sass/_skins.sass */
 .skin-2 .dashboard-header {
   background: rgba(255, 255, 255, 0.4);
   border-bottom: none !important;
   border-top: none;
-  padding: 20px 30px 20px 30px;
-}
+  padding: 20px 30px 20px 30px; }
 
-/* line 249, ../../sass/_skins.sass */
 .skin-2 .wrapper-content {
-  padding: 30px 15px;
-}
+  padding: 30px 15px; }
 
-/* line 253, ../../sass/_skins.sass */
 .skin-2 .dashoard-1 .wrapper-content {
-  padding: 0 30px 25px 30px;
-}
+  padding: 0 30px 25px 30px; }
 
-/* line 257, ../../sass/_skins.sass */
 .skin-2 .ibox-title {
   background: rgba(255, 255, 255, 0.7);
   border: none;
-  margin-bottom: 1px;
-}
+  margin-bottom: 1px; }
 
-/* line 263, ../../sass/_skins.sass */
 .skin-2 .ibox-content {
   background: rgba(255, 255, 255, 0.4);
-  border: none !important;
-}
+  border: none !important; }
 
-/* line 268, ../../sass/_skins.sass */
 .skin-2 #page-wrapper {
   background: #f6f6f6;
   background: -webkit-radial-gradient(center, ellipse cover, #f6f6f6 20%, #d5d5d5 100%);
   background: -o-radial-gradient(center, ellipse cover, #f6f6f6 20%, #d5d5d5 100%);
   background: -ms-radial-gradient(center, ellipse cover, #f6f6f6 20%, #d5d5d5 100%);
   background: radial-gradient(ellipse at center, #f6f6f6 20%, #d5d5d5 100%);
-  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#f6f6f6, endColorstr=#d5d5d5)";
-}
+  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#f6f6f6, endColorstr=#d5d5d5)"; }
 
-/* line 277, ../../sass/_skins.sass */
 .skin-2 .ibox-title, .skin-2 .ibox-content {
-  border-width: 1px;
-}
+  border-width: 1px; }
 
-/* line 281, ../../sass/_skins.sass */
 .skin-2 .ibox-content:last-child {
-  border-style: solid solid solid solid;
-}
+  border-style: solid solid solid solid; }
 
-/* line 285, ../../sass/_skins.sass */
 .skin-2 .nav > li.active {
-  border: none;
-}
+  border: none; }
 
-/* line 289, ../../sass/_skins.sass */
 .skin-2 .nav-header a.dropdown-toggle {
   color: #edf6ff;
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 294, ../../sass/_skins.sass */
 .skin-2 .nav-header a.dropdown-toggle .text-muted {
   color: #edf6ff;
-  opacity: 0.8;
-}
+  opacity: 0.8; }
 
-/* line 299, ../../sass/_skins.sass */
 .skin-2 .img-circle {
-  border-radius: 10px;
-}
+  border-radius: 10px; }
 
-/* line 303, ../../sass/_skins.sass */
 .skin-2 .nav.navbar-top-links > li > a:hover, .skin-2 .nav.navbar-top-links > li > a:focus {
-  background: #1a2d41;
-}
+  background: #1a2d41; }
 
-/* line 307, ../../sass/_skins.sass */
 .skin-2 .navbar-default .nav > li > a:hover, .skin-2 .navbar-default .nav > li > a:focus {
   background: #e0e0e0;
-  color: #213a53;
-}
+  color: #213a53; }
 
-/* line 312, ../../sass/_skins.sass */
 .skin-2 .nav.nav-tabs > li.active > a {
-  color: #555;
-}
+  color: #555; }
 
-/* line 316, ../../sass/_skins.sass */
 .skin-2 .nav.nav-tabs > li.active {
-  background: transparent;
-}
+  background: transparent; }
 
-/* line 327, ../../sass/_skins.sass */
 .skin-3 .minimalize-styl-2 {
-  margin: 14px 5px 5px 30px;
-}
+  margin: 14px 5px 5px 30px; }
 
-/* line 331, ../../sass/_skins.sass */
 .skin-3 .navbar-top-links li:last-child {
-  margin-right: 30px;
-}
+  margin-right: 30px; }
 
-/* line 335, ../../sass/_skins.sass */
 .skin-3.fixed-nav .minimalize-styl-2 {
-  margin: 14px 5px 5px 15px;
-}
+  margin: 14px 5px 5px 15px; }
 
-/* line 339, ../../sass/_skins.sass */
 .skin-3 .spin-icon {
-  background: #ecba52 !important;
-}
+  background: #ecba52 !important; }
 
-/* line 343, ../../sass/_skins.sass */
 body.boxed-layout.skin-3 #wrapper {
-  background: #3e2c42;
-}
+  background: #3e2c42; }
 
-/* line 347, ../../sass/_skins.sass */
 .skin-3 .nav-header {
   background-color: #ecba52;
-  background-image: url("patterns/header-profile-skin-3.png");
-}
+  background-image: url("patterns/header-profile-skin-3.png"); }
 
-/* line 352, ../../sass/_skins.sass */
 .skin-3.mini-navbar .nav-second-level {
-  background: #3e2c42;
-}
+  background: #3e2c42; }
 
-/* line 356, ../../sass/_skins.sass */
 .skin-3 .breadcrumb {
-  background: transparent;
-}
+  background: transparent; }
 
-/* line 360, ../../sass/_skins.sass */
 .skin-3 .page-heading {
-  border: none;
-}
+  border: none; }
 
-/* line 363, ../../sass/_skins.sass */
 .skin-3 ul.nav-second-level {
-  background-color: inherit;
-}
+  background-color: inherit; }
 
-/* line 366, ../../sass/_skins.sass */
 .skin-3 .nav > li.active {
-  background: #38283c;
-}
+  background: #38283c; }
 
-/* line 370, ../../sass/_skins.sass */
 .fixed-nav.skin-3 .navbar-fixed-top {
-  background: #fff;
-}
+  background: #fff; }
 
-/* line 374, ../../sass/_skins.sass */
 .skin-3 .nav > li > a {
-  color: #948b96;
-}
+  color: #948b96; }
 
-/* line 378, ../../sass/_skins.sass */
 .skin-3 .nav > li.active > a {
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 382, ../../sass/_skins.sass */
 .skin-3 .navbar-minimalize {
   background: #ecba52;
-  border-color: #ecba52;
-}
+  border-color: #ecba52; }
 
-/* line 387, ../../sass/_skins.sass */
 body.skin-3 {
-  background: #3e2c42;
-}
+  background: #3e2c42; }
 
-/* line 391, ../../sass/_skins.sass */
 .skin-3 .navbar-static-top {
-  background: #ffffff;
-}
+  background: #ffffff; }
 
-/* line 395, ../../sass/_skins.sass */
 .skin-3 .dashboard-header {
   background: transparent;
   border-bottom: none !important;
   border-top: none;
-  padding: 20px 30px 10px 30px;
-}
+  padding: 20px 30px 10px 30px; }
 
-/* line 402, ../../sass/_skins.sass */
 .skin-3 .wrapper-content {
-  padding: 30px 15px;
-}
+  padding: 30px 15px; }
 
-/* line 406, ../../sass/_skins.sass */
 .skin-3 #page-wrapper {
-  background: #f4f6fa;
-}
+  background: #f4f6fa; }
 
-/* line 410, ../../sass/_skins.sass */
 .skin-3 .ibox-title, .skin-3 .ibox-content {
-  border-width: 1px;
-}
+  border-width: 1px; }
 
-/* line 414, ../../sass/_skins.sass */
 .skin-3 .ibox-content:last-child {
-  border-style: solid solid solid solid;
-}
+  border-style: solid solid solid solid; }
 
-/* line 418, ../../sass/_skins.sass */
 .skin-3 .nav > li.active {
-  border: none;
-}
+  border: none; }
 
-/* line 422, ../../sass/_skins.sass */
 .skin-3 .nav-header {
-  padding: 35px 25px 25px 25px;
-}
+  padding: 35px 25px 25px 25px; }
 
-/* line 426, ../../sass/_skins.sass */
 .skin-3 .nav-header a.dropdown-toggle {
   color: #fff;
-  margin-top: 10px;
-}
+  margin-top: 10px; }
 
-/* line 431, ../../sass/_skins.sass */
 .skin-3 .nav-header a.dropdown-toggle .text-muted {
   color: #fff;
-  opacity: 0.8;
-}
+  opacity: 0.8; }
 
-/* line 436, ../../sass/_skins.sass */
 .skin-3 .profile-element {
-  text-align: center;
-}
+  text-align: center; }
 
-/* line 440, ../../sass/_skins.sass */
 .skin-3 .img-circle {
-  border-radius: 5px;
-}
+  border-radius: 5px; }
 
-/* line 444, ../../sass/_skins.sass */
 .skin-3 .navbar-default .nav > li > a:hover, .skin-3 .navbar-default .nav > li > a:focus {
   background: #38283c;
-  color: #fff;
-}
+  color: #fff; }
 
-/* line 449, ../../sass/_skins.sass */
 .skin-3 .nav.nav-tabs > li.active > a {
-  color: #555;
-}
+  color: #555; }
 
-/* line 453, ../../sass/_skins.sass */
 .skin-3 .nav.nav-tabs > li.active {
-  background: transparent;
-}
+  background: transparent; }
 
-/* line 6, ../../sass/_md-skin.sass */
 body.md-skin {
   font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  background-color: #ffffff;
-}
+  background-color: #ffffff; }
 
-/* line 13, ../../sass/_md-skin.sass */
 .md-skin .nav-header {
-  background: url("patterns/4.png") no-repeat;
-}
-/* line 16, ../../sass/_md-skin.sass */
+  background: url("patterns/4.png") no-repeat; }
 .md-skin .label, .md-skin .badge {
-  font-family: "Roboto";
-}
-/* line 19, ../../sass/_md-skin.sass */
+  font-family: "Roboto"; }
 .md-skin ul.nav-second-level {
-  background-color: inherit;
-}
-/* line 22, ../../sass/_md-skin.sass */
+  background-color: inherit; }
 .md-skin .font-bold {
-  font-weight: 500;
-}
-/* line 26, ../../sass/_md-skin.sass */
+  font-weight: 500; }
 .md-skin .wrapper-content {
-  padding: 30px 20px 40px;
-}
+  padding: 30px 20px 40px; }
 @media (max-width: 768px) {
-  /* line 31, ../../sass/_md-skin.sass */
   .md-skin .wrapper-content {
-    padding: 30px 0 40px;
-  }
-}
-/* line 35, ../../sass/_md-skin.sass */
+    padding: 30px 0 40px; } }
 .md-skin .page-heading {
   border-bottom: none !important;
   border-top: 0;
   padding: 0 10px 20px 10px;
-  box-shadow: 0 1px 1px -1px rgba(0, 0, 0, 0.34), 0 0 6px 0 rgba(0, 0, 0, 0.14);
-}
-/* line 42, ../../sass/_md-skin.sass */
+  box-shadow: 0 1px 1px -1px rgba(0, 0, 0, 0.34), 0 0 6px 0 rgba(0, 0, 0, 0.14); }
 .md-skin .full-height-layout .page-heading {
-  border-bottom: 1px solid #e7eaec !important;
-}
-/* line 46, ../../sass/_md-skin.sass */
+  border-bottom: 1px solid #e7eaec !important; }
 .md-skin .ibox {
   clear: both;
   margin-bottom: 25px;
   margin-top: 0;
   padding: 0;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-/* line 54, ../../sass/_md-skin.sass */
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 .md-skin .ibox.border-bottom {
-  border-bottom: none !important;
-}
-/* line 58, ../../sass/_md-skin.sass */
+  border-bottom: none !important; }
 .md-skin .ibox-title, .md-skin .ibox-content {
-  border-style: none;
-}
-/* line 62, ../../sass/_md-skin.sass */
+  border-style: none; }
 .md-skin .ibox-title h5 {
   font-size: 16px;
-  font-weight: 400;
-}
-/* line 67, ../../sass/_md-skin.sass */
+  font-weight: 400; }
 .md-skin a.close-canvas-menu {
-  color: #ffffff;
-}
-/* line 71, ../../sass/_md-skin.sass */
+  color: #ffffff; }
 .md-skin .welcome-message {
   color: #ffffff;
-  font-weight: 300;
-}
-/* line 76, ../../sass/_md-skin.sass */
+  font-weight: 300; }
 .md-skin #top-search::-moz-placeholder {
-  color: #ffffff;
-}
-/* line 80, ../../sass/_md-skin.sass */
+  color: #ffffff; }
 .md-skin #top-search::-webkit-input-placeholder {
-  color: #ffffff;
-}
-/* line 84, ../../sass/_md-skin.sass */
+  color: #ffffff; }
 .md-skin #nestable-output,
 .md-skin #nestable2-output {
-  font-family: "Roboto", lucida grande, lucida sans unicode, helvetica, arial, sans-serif;
-}
-/* line 89, ../../sass/_md-skin.sass */
+  font-family: "Roboto", lucida grande, lucida sans unicode, helvetica, arial, sans-serif; }
 .md-skin .landing-page {
-  font-family: "Roboto", helvetica, arial, sans-serif;
-}
-/* line 93, ../../sass/_md-skin.sass */
+  font-family: "Roboto", helvetica, arial, sans-serif; }
 .md-skin .landing-page.navbar-default.navbar-scroll {
-  background-color: #fff !important;
-}
-/* line 96, ../../sass/_md-skin.sass */
+  background-color: #fff !important; }
 .md-skin .landing-page.navbar-default {
   background-color: transparent !important;
-  box-shadow: none;
-}
-/* line 100, ../../sass/_md-skin.sass */
+  box-shadow: none; }
 .md-skin .landing-page.navbar-default .nav li a {
-  font-family: "Roboto", helvetica, arial, sans-serif;
-}
-/* line 104, ../../sass/_md-skin.sass */
+  font-family: "Roboto", helvetica, arial, sans-serif; }
 .md-skin .nav > li > a {
   color: #676a6c;
-  padding: 14px 20px 14px 25px;
-}
-/* line 109, ../../sass/_md-skin.sass */
+  padding: 14px 20px 14px 25px; }
 .md-skin .nav.navbar-right > li > a {
-  color: #ffffff;
-}
-/* line 113, ../../sass/_md-skin.sass */
+  color: #ffffff; }
 .md-skin .nav > li.active > a {
   color: #5b5d5f;
-  font-weight: 700;
-}
-/* line 118, ../../sass/_md-skin.sass */
+  font-weight: 700; }
 .md-skin .navbar-default .nav > li > a:hover, .md-skin .navbar-default .nav > li > a:focus {
   font-weight: 700;
-  color: #5b5d5f;
-}
-/* line 123, ../../sass/_md-skin.sass */
+  color: #5b5d5f; }
 .md-skin .nav .open > a, .md-skin .nav .open > a:hover, .md-skin .nav .open > a:focus {
-  background: #1ab394;
-}
-/* line 127, ../../sass/_md-skin.sass */
+  background: #1ab394; }
 .md-skin .navbar-top-links li {
-  display: inline-table;
-}
-/* line 131, ../../sass/_md-skin.sass */
+  display: inline-table; }
 .md-skin .navbar-top-links .dropdown-menu li {
-  display: block;
-}
-/* line 135, ../../sass/_md-skin.sass */
+  display: block; }
 .md-skin .pace-done .nav-header {
-  transition: all 0.4s;
-}
-/* line 139, ../../sass/_md-skin.sass */
+  transition: all 0.4s; }
 .md-skin .nav > li.active {
-  background: #f8f8f9;
-}
-/* line 143, ../../sass/_md-skin.sass */
+  background: #f8f8f9; }
 .md-skin .nav-second-level li a {
-  padding: 7px 10px 7px 52px;
-}
-/* line 146, ../../sass/_md-skin.sass */
+  padding: 7px 10px 7px 52px; }
 .md-skin .nav-third-level li a {
-  padding-left: 62px;
-}
-/* line 150, ../../sass/_md-skin.sass */
+  padding-left: 62px; }
 .md-skin .navbar-top-links li a {
   padding: 20px 10px;
-  min-height: 50px;
-}
-/* line 155, ../../sass/_md-skin.sass */
+  min-height: 50px; }
 .md-skin .nav > li > a {
-  font-weight: 400;
-}
-/* line 159, ../../sass/_md-skin.sass */
+  font-weight: 400; }
 .md-skin .navbar-static-side .nav > li > a:focus, .md-skin .navbar-static-side .nav > li > a:hover {
-  background-color: inherit;
-}
-/* line 163, ../../sass/_md-skin.sass */
+  background-color: inherit; }
 .md-skin .navbar-top-links .dropdown-menu li a {
   padding: 3px 20px;
-  min-height: inherit;
-}
-/* line 168, ../../sass/_md-skin.sass */
+  min-height: inherit; }
 .md-skin .nav-header .navbar-fixed-top a {
-  color: #ffffff;
-}
-/* line 172, ../../sass/_md-skin.sass */
+  color: #ffffff; }
 .md-skin .nav-header .text-muted {
-  color: #ffffff;
-}
-/* line 176, ../../sass/_md-skin.sass */
+  color: #ffffff; }
 .md-skin .navbar-form-custom .form-control {
-  font-weight: 300;
-}
-/* line 180, ../../sass/_md-skin.sass */
+  font-weight: 300; }
 .md-skin .mini-navbar .nav-second-level {
-  background-color: inherit;
-}
-/* line 184, ../../sass/_md-skin.sass */
+  background-color: inherit; }
 .md-skin .mini-navbar li.active .nav-second-level {
-  left: 65px;
-}
-/* line 188, ../../sass/_md-skin.sass */
+  left: 65px; }
 .md-skin .canvas-menu.mini-navbar .nav-second-level {
-  background: inherit;
-}
-/* line 192, ../../sass/_md-skin.sass */
+  background: inherit; }
 .md-skin .pace-done .navbar-static-side, .md-skin .pace-done .nav-header, .md-skin .pace-done li.active, .md-skin .pace-done #page-wrapper, .md-skin .pace-done .footer {
   -webkit-transition: all 0.4s;
   -moz-transition: all 0.4s;
   -o-transition: all 0.4s;
-  transition: all 0.4s;
-}
-/* line 199, ../../sass/_md-skin.sass */
+  transition: all 0.4s; }
 .md-skin .navbar-fixed-top {
   background: #fff;
   transition-duration: 0.4s;
   z-index: 2030;
-  border-bottom: none !important;
-}
-/* line 206, ../../sass/_md-skin.sass */
+  border-bottom: none !important; }
 .md-skin .navbar-fixed-top, .md-skin .navbar-static-top {
   background-color: #1AB394 !important;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-/* line 211, ../../sass/_md-skin.sass */
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 .md-skin .navbar-static-side {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-/* line 217, ../../sass/_md-skin.sass */
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 .md-skin #right-sidebar {
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   border: none;
-  z-index: 900;
-}
-/* line 223, ../../sass/_md-skin.sass */
+  z-index: 900; }
 .md-skin .white-bg .navbar-fixed-top, .md-skin .white-bg .navbar-static-top {
-  background: #fff !important;
-}
-/* line 227, ../../sass/_md-skin.sass */
+  background: #fff !important; }
 .md-skin .contact-box {
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-  border: none;
-}
-/* line 232, ../../sass/_md-skin.sass */
+  border: none; }
 .md-skin .dashboard-header {
   border-bottom: none !important;
   border-top: 0;
   padding: 20px 20px 20px 20px;
   margin: 30px 20px 0 20px;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 @media (max-width: 768px) {
-  /* line 241, ../../sass/_md-skin.sass */
   .md-skin .dashboard-header {
-    margin: 20px 0 0 0;
-  }
-}
-/* line 246, ../../sass/_md-skin.sass */
+    margin: 20px 0 0 0; } }
 .md-skin ul.notes li div {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-/* line 251, ../../sass/_md-skin.sass */
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 .md-skin .file {
   border: none;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-/* line 256, ../../sass/_md-skin.sass */
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 .md-skin .mail-box {
   background-color: #ffffff;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   padding: 0;
   margin-bottom: 20px;
-  border: none;
-}
-/* line 264, ../../sass/_md-skin.sass */
+  border: none; }
 .md-skin .mail-box-header {
   border: none;
   background-color: #ffffff;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-  padding: 30px 20px 20px 20px;
-}
-/* line 271, ../../sass/_md-skin.sass */
+  padding: 30px 20px 20px 20px; }
 .md-skin .mailbox-content {
   border: none;
   padding: 20px;
-  background: #ffffff;
-}
-/* line 277, ../../sass/_md-skin.sass */
+  background: #ffffff; }
 .md-skin .social-feed-box {
   border: none;
   background: #fff;
   margin-bottom: 15px;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-/* line 284, ../../sass/_md-skin.sass */
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 .md-skin.landing-page .navbar-default {
   background-color: transparent !important;
   border-color: transparent;
   transition: all 0.3s ease-in-out 0s;
-  box-shadow: none;
-}
-/* line 291, ../../sass/_md-skin.sass */
+  box-shadow: none; }
 .md-skin.landing-page .navbar-default.navbar-scroll, .md-skin.landing-page.body-small .navbar-default {
-  background-color: #ffffff !important;
-}
-/* line 297, ../../sass/_md-skin.sass */
+  background-color: #ffffff !important; }
 .md-skin.landing-page .nav > li.active {
-  background: inherit;
-}
-/* line 301, ../../sass/_md-skin.sass */
+  background: inherit; }
 .md-skin.landing-page .navbar-scroll .navbar-nav > li > a {
-  padding: 20px 10px;
-}
-/* line 305, ../../sass/_md-skin.sass */
+  padding: 20px 10px; }
 .md-skin.landing-page .navbar-default .nav li a {
-  font-family: "Roboto", helvetica, arial, sans-serif;
-}
-/* line 309, ../../sass/_md-skin.sass */
+  font-family: "Roboto", helvetica, arial, sans-serif; }
 .md-skin.landing-page .nav > li > a {
-  padding: 25px 10px 15px 10px;
-}
-/* line 313, ../../sass/_md-skin.sass */
+  padding: 25px 10px 15px 10px; }
 .md-skin.landing-page .navbar-default .navbar-nav > li > a:hover, .md-skin.landing-page .navbar-default .navbar-nav > li > a:focus {
   background: inherit;
-  color: #1ab394;
-}
-/* line 319, ../../sass/_md-skin.sass */
+  color: #1ab394; }
 .md-skin.landing-page.body-small .nav.navbar-right > li > a {
-  color: #676a6c;
-}
-/* line 323, ../../sass/_md-skin.sass */
+  color: #676a6c; }
 .md-skin .landing_link a, .md-skin .special_link a {
-  color: #ffffff !important;
-}
-/* line 327, ../../sass/_md-skin.sass */
+  color: #ffffff !important; }
 .md-skin.canvas-menu.mini-navbar .nav-second-level {
-  background: #f8f8f9;
-}
-/* line 331, ../../sass/_md-skin.sass */
+  background: #f8f8f9; }
 .md-skin.mini-navbar .nav-second-level {
   background-color: #ffffff;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-/* line 336, ../../sass/_md-skin.sass */
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12); }
 .md-skin.mini-navbar .nav-second-level li a {
-  padding-left: 0;
-}
-/* line 340, ../../sass/_md-skin.sass */
+  padding-left: 0; }
 .md-skin.top-navigation .nav.navbar-right > li > a {
   padding: 15px 20px;
-  color: #676a6c;
-}
-/* line 345, ../../sass/_md-skin.sass */
+  color: #676a6c; }
 .md-skin.top-navigation .nav > li a:hover, .md-skin .top-navigation .nav > li a:focus, .md-skin.top-navigation .nav .open > a, .md-skin.top-navigation .nav .open > a:hover, .md-skin.top-navigation .nav .open > a:focus {
   color: #1ab394;
-  background: #ffffff;
-}
-/* line 353, ../../sass/_md-skin.sass */
+  background: #ffffff; }
 .md-skin.top-navigation .nav > li.active a {
   color: #1ab394;
-  background: #ffffff;
-}
-/* line 357, ../../sass/_md-skin.sass */
+  background: #ffffff; }
 .md-skin.fixed-nav #side-menu {
-  background-color: #fff;
-}
-/* line 360, ../../sass/_md-skin.sass */
+  background-color: #fff; }
 .md-skin.fixed-nav #wrapper.top-navigation #page-wrapper {
-  margin-top: 0;
-}
-/* line 364, ../../sass/_md-skin.sass */
+  margin-top: 0; }
 .md-skin.fixed-sidebar.mini-navbar .navbar-static-side {
-  width: 0;
-}
-/* line 368, ../../sass/_md-skin.sass */
+  width: 0; }
 .md-skin.fixed-sidebar.mini-navbar #page-wrapper {
-  margin: 0 0 0 0;
-}
-/* line 372, ../../sass/_md-skin.sass */
+  margin: 0 0 0 0; }
 .md-skin.body-small.fixed-sidebar.mini-navbar #page-wrapper {
-  margin: 0 0 0 0;
-}
-/* line 376, ../../sass/_md-skin.sass */
+  margin: 0 0 0 0; }
 .md-skin.body-small.fixed-sidebar.mini-navbar .navbar-static-side {
   width: 220px;
-  background-color: #ffffff;
-}
-/* line 380, ../../sass/_md-skin.sass */
+  background-color: #ffffff; }
 .md-skin.boxed-layout #wrapper {
-  background-color: #ffffff;
-}
-/* line 383, ../../sass/_md-skin.sass */
+  background-color: #ffffff; }
 .md-skin.canvas-menu nav.navbar-static-side {
   z-index: 2001;
   background: #ffffff;
   height: 100%;
   position: fixed;
-  display: none;
-}
+  display: none; }
 
 @media (min-width: 768px) {
-  /* line 2, ../../sass/_media.sass */
   #page-wrapper {
     position: inherit;
     margin: 0 0 0 220px;
-    min-height: 100vh;
-  }
+    min-height: 100vh; }
 
-  /* line 8, ../../sass/_media.sass */
   .navbar-static-side {
     z-index: 2001;
     position: absolute;
-    width: 220px;
-  }
+    width: 220px; }
 
-  /* line 14, ../../sass/_media.sass */
   .navbar-top-links .dropdown-messages,
   .navbar-top-links .dropdown-tasks,
   .navbar-top-links .dropdown-alerts {
-    margin-left: auto;
-  }
-}
+    margin-left: auto; } }
 @media (max-width: 768px) {
-  /* line 23, ../../sass/_media.sass */
   #page-wrapper {
     position: inherit;
     margin: 0 0 0 0;
-    min-height: 100vh;
-  }
+    min-height: 100vh; }
 
-  /* line 29, ../../sass/_media.sass */
   .body-small .navbar-static-side {
     display: none;
     z-index: 2001;
     position: absolute;
-    width: 70px;
-  }
+    width: 70px; }
 
-  /* line 36, ../../sass/_media.sass */
   .body-small.mini-navbar .navbar-static-side {
-    display: block;
-  }
+    display: block; }
 
-  /* line 40, ../../sass/_media.sass */
   .lock-word {
-    display: none;
-  }
+    display: none; }
 
-  /* line 44, ../../sass/_media.sass */
   .navbar-form-custom {
-    display: none;
-  }
+    display: none; }
 
-  /* line 48, ../../sass/_media.sass */
   .navbar-header {
     display: inline;
-    float: left;
-  }
+    float: left; }
 
-  /* line 53, ../../sass/_media.sass */
   .sidebar-panel {
     z-index: 2;
     position: relative;
     width: auto;
-    min-height: 100% !important;
-  }
+    min-height: 100% !important; }
 
-  /* line 60, ../../sass/_media.sass */
   .sidebar-content .wrapper {
     padding-right: 0;
-    z-index: 1;
-  }
+    z-index: 1; }
 
-  /* line 65, ../../sass/_media.sass */
   .fixed-sidebar.body-small .navbar-static-side {
     display: none;
     z-index: 2001;
     position: fixed;
-    width: 220px;
-  }
+    width: 220px; }
 
-  /* line 72, ../../sass/_media.sass */
   .fixed-sidebar.body-small.mini-navbar .navbar-static-side {
-    display: block;
-  }
+    display: block; }
 
-  /* line 76, ../../sass/_media.sass */
   .ibox-tools {
     float: none;
     text-align: right;
-    display: block;
-  }
+    display: block; }
 
-  /* line 81, ../../sass/_media.sass */
   .navbar-static-side {
-    display: none;
-  }
+    display: none; }
 
-  /* line 84, ../../sass/_media.sass */
   body:not(.mini-navbar) {
     -webkit-transition: background-color 500ms linear;
     -moz-transition: background-color 500ms linear;
     -o-transition: background-color 500ms linear;
     -ms-transition: background-color 500ms linear;
     transition: background-color 500ms linear;
-    background-color: #f3f3f4;
-  }
-}
+    background-color: #f3f3f4; } }
 @media (max-width: 350px) {
-  /* line 96, ../../sass/_media.sass */
   .timeline-item .date {
     text-align: left;
     width: 110px;
     position: relative;
-    padding-top: 30px;
-  }
+    padding-top: 30px; }
 
-  /* line 103, ../../sass/_media.sass */
   .timeline-item .date i {
     position: absolute;
     top: 0;
@@ -11113,89 +7535,61 @@ body.md-skin {
     width: 30px;
     text-align: center;
     border: 1px solid #e7eaec;
-    background: #f8f8f8;
-  }
+    background: #f8f8f8; }
 
-  /* line 114, ../../sass/_media.sass */
   .timeline-item .content {
     border-left: none;
     border-top: 1px solid #e7eaec;
     padding-top: 10px;
-    min-height: 100px;
-  }
+    min-height: 100px; }
 
-  /* line 121, ../../sass/_media.sass */
   .nav.navbar-top-links li.dropdown {
-    display: none;
-  }
+    display: none; }
 
-  /* line 125, ../../sass/_media.sass */
   .ibox-tools {
     float: none;
     text-align: left;
-    display: inline-block;
-  }
-}
+    display: inline-block; } }
 /* Only demo */
 @media (max-width: 1000px) {
-  /* line 3, ../../sass/_custom.sass */
   .welcome-message {
-    display: none;
-  }
-}
+    display: none; } }
 @media print {
-  /* line 46, ../../sass/style.sass */
   nav.navbar-static-side {
-    display: none;
-  }
+    display: none; }
 
-  /* line 49, ../../sass/style.sass */
   body {
-    overflow: visible !important;
-  }
+    overflow: visible !important; }
 
-  /* line 52, ../../sass/style.sass */
   #page-wrapper {
-    margin: 0;
-  }
-}
-/* line 55, ../../sass/style.sass */
+    margin: 0; } }
 .owner img.img-circle {
   max-width: 38px;
   max-height: 38px;
   width: 38px;
-  height: 38px;
-}
+  height: 38px; }
 
-/* line 61, ../../sass/style.sass */
 .node circle {
-  fill: red;
-}
+  fill: red; }
 
-/* line 64, ../../sass/style.sass */
 .node text {
   font-family: "open sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   stroke: none;
-  color: #676a6c;
-}
+  color: #676a6c; }
 
-/* line 69, ../../sass/style.sass */
 .node text-anchor {
   font-family: "open sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   stroke: none;
   color: #676a6c;
-  font-weight: normal;
-}
+  font-weight: normal; }
 
-/* line 75, ../../sass/style.sass */
 .node--internal circle {
-  fill: darkred;
-}
+  fill: darkred; }
 
-/* line 78, ../../sass/style.sass */
 .link {
   fill: none;
   stroke: blue;
   stroke-opacity: 0.4;
-  stroke-width: 2px;
-}
+  stroke-width: 2px; }
+
+/*# sourceMappingURL=style.css.map */

--- a/dashboard/src/repositories/index.html
+++ b/dashboard/src/repositories/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
     <!-- Page title set in pageTitle directive -->
     <title page-title>Repositories</title>
 
@@ -53,8 +53,8 @@
                   <li class="active"><a data-toggle="tab" href="#tab-1" aria-expanded="true">Search</a></li>
                   <li class=""><a data-toggle="tab" href="#tab-2" aria-expanded="false">Stats</a></li>
                 </ul>
-                
-                
+
+
                 <div class="tab-content">
                   <div id="tab-1" class="tab-pane active">
                     <div class="panel-body">
@@ -68,7 +68,7 @@
                           </form>
                         </div>
                       </div>
-                      
+
                       <div class="row">
                         <div class="col-lg-12">
                           <table class="table">
@@ -77,9 +77,7 @@
                                 <th>Owner</th>
                                 <th>Created</th>
                                 <th>Project</th>
-                                <th></th>
                                 <th align="right">Stats</th>
-                                <th>Snapshot</th>
                               </tr>
                             </thead>
                             <tbody>
@@ -87,14 +85,16 @@
                                 <td class="owner">
                                   <img alt="image" class="img-circle" ng-src="{{i.project.owner.avatar_url}}">
                                 </td>
-                                <td nowrap>{{i.project.created_at  | date:'yyyy-MM-dd'}}</td>
-                                <td nowrap><a href="{{i.project.html_url}}"><i class="fa fa-github" aria-hidden="true"></i>&nbsp;{{i.project.name}}</a></td>
-                                <td><p class="text-muted">{{i.project.description}}</p></td>
-                                <td align="right" nowrap>{{i.project.watchers | number}}&nbsp;watchers<br/>
+                                <td class="created-at">{{i.project.created_at  | date:'yyyy-MM-dd'}}</td>
+                                <td>
+                                  <h3>{{i.project.name}}</h3><a href="/snapshot?id={{i.id}}"><i class="fa fa-bar-chart" aria-hidden="true"></i>&nbsp;Snapshot</a>&nbsp;&vert;&nbsp;<a href="{{i.project.html_url}}"><i class="fa fa-github" aria-hidden="true"></i>&nbsp;Github</a>
+                                  <p class="text-muted">{{i.project.description}}</p>
+                                </td>
+                                <td align="right" class="stats">{{i.project.watchers | number}}&nbsp;watchers<br/>
                                   {{i.project.open_issues_count | number}} open issues<br/>
                                   {{i.project.forks | number}} forks<br/>
-                                  {{i.project.size | number}} kb</td>
-                                <td nowrap><a href="/snapshot?id={{i.id}}"><i class="fa fa-file-image-o" aria-hidden="true"></i>&nbsp;Snapshot</a></td>
+                                  {{i.project.size | number}} kb
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -116,7 +116,7 @@
                               <small>Registered repositories</small>
                             </div>
                           </div>
-                          
+
                           <div class="ibox float-e-margins">
                             <div class="ibox-title">
                               <h5>Version Control Revision entries</h5>
@@ -126,7 +126,7 @@
                               <small>Revision history records</small>
                             </div>
                           </div>
-                          
+
                           <div class="ibox float-e-margins">
                             <div class="ibox-title">
                               <h5>Code metrics</h5>
@@ -136,9 +136,9 @@
                               <small>Number of collected code metrics</small>
                             </div>
                           </div>
-                          
+
                         </div>
-                      
+
                         <div class="col-lg-6">
                           <div class="panel panel-default float-e-margins">
                             <div class="panel-heading">
@@ -157,7 +157,7 @@
 
                   </div>
                 </div>
-                
+
               </div>
             </div>
           </div>
@@ -172,11 +172,11 @@
 
 
 
-          
-          
-          
-          
-          
+
+
+
+
+
           <div class="row">
             <div class="col-lg-12">
               <div class="text-center m-t-lg">
@@ -188,7 +188,7 @@
                 </small>
               </div>
             </div>
-          </div>    
+          </div>
         </div>
       </div>
     </div>
@@ -196,16 +196,16 @@
     <script src="/js/jquery/jquery-2.1.1.min.js"></script>
     <script src="/js/plugins/jquery-ui/jquery-ui.js"></script>
     <script src="/js/bootstrap/bootstrap.min.js"></script>
-    
+
     <!-- MetsiMenu -->
     <script src="/js/plugins/metisMenu/jquery.metisMenu.js"></script>
-    
+
     <!-- SlimScroll -->
     <script src="/js/plugins/slimscroll/jquery.slimscroll.min.js"></script>
-    
+
     <!-- Custom and plugin javascript -->
     <script src="/js/inspinia.js"></script>
-    
+
     <!-- Main Angular scripts-->
     <script src="/js/angular/angular.js"></script>
     <script src="/js/angular/angular-websocket.js"></script>


### PR DESCRIPTION
Search results table was not properly displaying with screen width under ~1130px. 

This PR tries to improve these design points:
- Search results table works well with screen width 720px and above.
- Moved the "Snapshot" link under the title of the project and next to "Github" link. It becomes then a conscious choice to either view the stats or visit the repo.
- Changing the icon for "Snapshot". While, indeed, a snapshot is literally an instant image of a project, what the user will access are graphs, bar charts and tables.
- The `nowrap` attribute is [deprecated in HTML5](https://www.w3schools.com/TAGS/att_td_nowrap.asp). So it's replaced by the CSS equivalent. 

Preview:
<img width="717" alt="screen shot 2017-08-25 at 22 19 11" src="https://user-images.githubusercontent.com/192539/29737938-79a3e036-89e5-11e7-94f9-45dbb9fb60c0.png">
 