### PR TITLE
Snapshot page design improvements

### DIFF
--- a/dashboard/sass/_top_navigation.sass
+++ b/dashboard/sass/_top_navigation.sass
@@ -57,8 +57,6 @@
   background: $navy
   color: #fff
 
-
-
 .top-navigation .navbar-top-links li:last-child
   margin-right: 0
 

--- a/dashboard/sass/style.sass
+++ b/dashboard/sass/style.sass
@@ -57,6 +57,10 @@
   max-height: 38px
   width: 38px
   height: 38px
+  margin-right: 5px
+
+.owner .description
+  margin-top: 2em
 
 .node circle
   fill: red
@@ -80,4 +84,3 @@
   stroke: blue
   stroke-opacity: 0.4
   stroke-width: 2px // 1.5px
-

--- a/dashboard/src/css/style.css
+++ b/dashboard/src/css/style.css
@@ -7571,7 +7571,11 @@ table {
   max-width: 38px;
   max-height: 38px;
   width: 38px;
-  height: 38px; }
+  height: 38px;
+  margin-right: 5px; }
+
+.owner .description {
+  margin-top: 2em; }
 
 .node circle {
   fill: red; }

--- a/dashboard/src/directives/repository-panel.html
+++ b/dashboard/src/directives/repository-panel.html
@@ -1,7 +1,8 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h5><i class="fa fa-github"></i> Project data
-      <small>last updated {{ repository.updated_at  | date:'yyyy-MM-dd' }}.</small>
+    <h5>
+      <i class="fa fa-github"></i> Project data
+      <small class="pull-right">Last updated <span class="label label-primary">{{ repository.updated_at  | date:'yyyy-MM-dd' }}</span></small>
     </h5>
   </div>
   <div class="panel-body">
@@ -22,7 +23,7 @@
       <div class="col-sm-6 text-navy">{{ repository.stargazers_count | number }}</div>
     </div>
     <div class="row">
-      <div class="col-sm-6"><i class="fa fa-circle-o" aria-hidden="true"></i>Size (kb)</div>
+      <div class="col-sm-6"><i class="fa fa-circle-o" aria-hidden="true"></i> Size (kb)</div>
       <div class="col-sm-6 text-navy">{{ repository.size | number }}</div>
     </div>
     <div class="row">

--- a/dashboard/src/snapshot/index.html
+++ b/dashboard/src/snapshot/index.html
@@ -25,103 +25,86 @@
     <div class="row gray-bg {{$state.current.name}}">
       <div ng-include="'/views/common/navigation.html'"></div>
         <div class="col-sm-12 animated fadeIn">
-          <div class="row ibox">
-            <div class="col-sm-12 ibox-title owner">
-              <table>
-                <tr>
-                  <td>
-                    <img alt="image" class="img-circle" ng-src="{{ avatar_url }}">
-                  </td>
-                  <td>
-                    <h2>{{snapshot.repository.name}} Snapshot</h2>
-                    <p class="small text-muted">{{snapshot.repository.description}}</p>
-                    <a href="{{repository.project.html_url}}"> {{repository.project.html_url}} <i class="fa fa-github"></i></a>
-                  </td>
-                </tr>
-              </table>
+          <div class="row owner">
+            <div class="col-sm-6">
+              <h1><img alt="image" class="img-circle" ng-src="{{ avatar_url }}">{{snapshot.repository.name}} Snapshot</h1>
             </div>
-            <div class="col-sm-12 ibox-content">
-              <div class="row">
-                <div class="col-lg-12 owner"></div>
-                <div class="col-lg-12">
-                  <div class="tabs-container">
-                    <ul class="nav nav-tabs">
-                      <li class="active"><a data-toggle="tab" href="#tab-1" aria-expanded="true">Repository Info</a></li>
-                      <li class=""><a data-toggle="tab" href="#tab-2" aria-expanded="false">Recent History</a></li>
-                      <li class=""><a data-toggle="tab" href="#tab-3" aria-expanded="false">Modules</a></li>
-                    </ul>
-                    <div class="tab-content">
-                      <div id="tab-1" class="tab-pane active">
-                        <div class="panel-body">
-                          <div class="row">
-                            <div class="col-lg-2">
-                              <div class="row">
-                                <div class="col-lg-12">
-                                  <repository-panel repository="snapshot.repository"/>
-                                </div>
-                              </div>
-
-                              <div class="row">
-                                <div class="col-lg-12">
-                                  <content-panel content="snapshot.content"/>
-                                </div>
-                              </div>
-
-                              <div class="row">
-                                <div class="col-lg-12">
-                                  <build-panel build="snapshot.build"/>
-                                </div>
-                              </div>
-                            </div>
-
-                            <div class="col-lg-5">
-                              <div class="panel panel-primary">
-                                <div class="panel-heading">
-                                  <h5><i class="fa fa-file"></i>&nbsp;File Counts</h5>
-                                </div>
-                                <div class="panel-content">
-                                  <canvas id="filesBarCanvas"></canvas>
-                                </div>
-                              </div>
-                            </div>
-
-                            <div class="col-lg-5">
-                              <div class="panel panel-info">
-                                <div class="panel-heading">
-                                  <h5><i class="fa fa-file"></i> Lines of code</h5>
-                                </div>
-                                <div class="panel-content">
-                                  <canvas id="codeBarCanvas"></canvas>
-                                </div>
-                              </div>
-                            </div>
-
+            <div class="col-sm-6 description">
+              <p class="small text-muted">{{snapshot.repository.description}}<br>
+              <a href="{{repository.project.html_url}}">{{repository.project.html_url}} <i class="fa fa-github"></i></a>
+              </p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-lg-12">
+              <div class="tabs-container">
+                <ul class="nav nav-tabs">
+                  <li class="active"><a data-toggle="tab" href="#tab-1" aria-expanded="true">Repository Info</a></li>
+                  <li class=""><a data-toggle="tab" href="#tab-2" aria-expanded="false">Recent History</a></li>
+                  <li class=""><a data-toggle="tab" href="#tab-3" aria-expanded="false">Modules</a></li>
+                </ul>
+                <div class="tab-content">
+                  <div id="tab-1" class="tab-pane active">
+                    <div class="panel-body">
+                      <div class="row">
+                        <div class="col-lg-4">
+                          <div>
+                              <repository-panel repository="snapshot.repository"/>
+                          </div>
+                          <div>
+                              <content-panel content="snapshot.content"/>
+                          </div>
+                          <div>
+                              <build-panel build="snapshot.build"/>
                           </div>
                         </div>
-                      </div>
 
-                      <div id="tab-2" class="tab-pane">
-                        <div class="panel-body">
-                          <div class="row">
-                            <div class="col-lg-12">
-                              <commits-panel commits="commits" count='7'/>
+                        <div class="col-lg-4">
+                          <div class="panel panel-primary">
+                            <div class="panel-heading">
+                              <h5><i class="fa fa-file"></i>&nbsp;File Counts</h5>
+                            </div>
+                            <div class="panel-content">
+                              <canvas id="filesBarCanvas"></canvas>
                             </div>
                           </div>
                         </div>
-                      </div>
 
-                      <div id="tab-3" class="tab-pane">
-                        <div class="panel-body">
-                          <div class="row">
-                            <div ng-repeat="build in snapshot.build | orderBy: 'artifact.name'" class="col-lg-4">
-                              <artifact-panel path="build.path" artifact="build.artifact" dependency-tree="build.dependencyTree"></artifact-panel>
+                        <div class="col-lg-4">
+                          <div class="panel panel-info">
+                            <div class="panel-heading">
+                              <h5><i class="fa fa-file"></i> Lines of code</h5>
+                            </div>
+                            <div class="panel-content">
+                              <canvas id="codeBarCanvas"></canvas>
                             </div>
                           </div>
                         </div>
-                      </div>
 
+                      </div>
                     </div>
                   </div>
+
+                  <div id="tab-2" class="tab-pane">
+                    <div class="panel-body">
+                      <div class="row">
+                        <div class="col-lg-12">
+                          <commits-panel commits="commits" count='7'/>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div id="tab-3" class="tab-pane">
+                    <div class="panel-body">
+                      <div class="row">
+                        <div ng-repeat="build in snapshot.build | orderBy: 'artifact.name'" class="col-lg-4">
+                          <artifact-panel path="build.path" artifact="build.artifact" dependency-tree="build.dependencyTree"></artifact-panel>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Trying to make Snapshot page consistent with Repository search page. 
Basically, a page it a title and some info on a grey background with, under it, a couple white tabs with some content.

Preview
<img width="1440" alt="screen shot 2017-08-29 at 22 43 13" src="https://user-images.githubusercontent.com/192539/29853127-1cd176b4-8d0c-11e7-91cb-ed85b76f7816.png">
